### PR TITLE
Schism of SpecificRemapper and WatchedType

### DIFF
--- a/src/protocolsupport/ProtocolSupport.java
+++ b/src/protocolsupport/ProtocolSupport.java
@@ -19,6 +19,7 @@ import protocolsupport.protocol.packet.handler.AbstractLoginListener;
 import protocolsupport.protocol.pipeline.initial.InitialPacketDecoder;
 import protocolsupport.protocol.typeremapper.id.IdRemapper;
 import protocolsupport.protocol.typeremapper.watchedentity.remapper.SpecificRemapper;
+import protocolsupport.protocol.typeremapper.watchedentity.types.WatchedType;
 import protocolsupport.protocol.typeskipper.id.IdSkipper;
 import protocolsupport.protocol.utils.data.ItemData;
 import protocolsupport.protocol.utils.data.PotionData;
@@ -43,6 +44,7 @@ public class ProtocolSupport extends JavaPlugin {
 		}
 		try {
 			ProtocolVersion.values();
+			WatchedType.init();
 			Allocator.init();
 			ItemData.init();
 			PotionData.init();

--- a/src/protocolsupport/protocol/packet/middle/clientbound/play/MiddleSpawnLiving.java
+++ b/src/protocolsupport/protocol/packet/middle/clientbound/play/MiddleSpawnLiving.java
@@ -9,9 +9,9 @@ import protocolsupport.api.ProtocolVersion;
 import protocolsupport.protocol.packet.middle.ClientBoundMiddlePacket;
 import protocolsupport.protocol.serializer.MiscSerializer;
 import protocolsupport.protocol.serializer.VarNumberSerializer;
-import protocolsupport.protocol.typeremapper.watchedentity.remapper.SpecificRemapper;
 import protocolsupport.protocol.typeremapper.watchedentity.types.WatchedEntity;
 import protocolsupport.protocol.typeremapper.watchedentity.types.WatchedLiving;
+import protocolsupport.protocol.typeremapper.watchedentity.types.WatchedType;
 import protocolsupport.protocol.utils.datawatcher.DataWatcherDeserializer;
 import protocolsupport.protocol.utils.datawatcher.DataWatcherObject;
 
@@ -57,7 +57,7 @@ public abstract class MiddleSpawnLiving extends ClientBoundMiddlePacket {
 
 	@Override
 	public boolean isValid() {
-		return SpecificRemapper.getMobByTypeId(type) != SpecificRemapper.NONE;
+		return WatchedType.getMobByTypeId(type) != WatchedType.NONE;
 	}
 
 }

--- a/src/protocolsupport/protocol/packet/middle/clientbound/play/MiddleSpawnObject.java
+++ b/src/protocolsupport/protocol/packet/middle/clientbound/play/MiddleSpawnObject.java
@@ -6,8 +6,8 @@ import io.netty.buffer.ByteBuf;
 import protocolsupport.protocol.packet.middle.ClientBoundMiddlePacket;
 import protocolsupport.protocol.serializer.MiscSerializer;
 import protocolsupport.protocol.serializer.VarNumberSerializer;
-import protocolsupport.protocol.typeremapper.watchedentity.remapper.SpecificRemapper;
 import protocolsupport.protocol.typeremapper.watchedentity.types.WatchedObject;
+import protocolsupport.protocol.typeremapper.watchedentity.types.WatchedType;
 
 public abstract class MiddleSpawnObject extends ClientBoundMiddlePacket {
 
@@ -47,7 +47,7 @@ public abstract class MiddleSpawnObject extends ClientBoundMiddlePacket {
 
 	@Override
 	public boolean isValid() {
-		return SpecificRemapper.getObjectByTypeId(type) != SpecificRemapper.NONE;
+		return WatchedType.getObjectByTypeId(type) != WatchedType.NONE;
 	}
 
 }

--- a/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_1_7/EntityTeleport.java
+++ b/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_1_7/EntityTeleport.java
@@ -4,8 +4,8 @@ import protocolsupport.api.ProtocolVersion;
 import protocolsupport.protocol.packet.ClientBoundPacket;
 import protocolsupport.protocol.packet.middle.clientbound.play.MiddleEntityTeleport;
 import protocolsupport.protocol.packet.middleimpl.ClientBoundPacketData;
-import protocolsupport.protocol.typeremapper.watchedentity.remapper.SpecificRemapper;
 import protocolsupport.protocol.typeremapper.watchedentity.types.WatchedEntity;
+import protocolsupport.protocol.typeremapper.watchedentity.types.WatchedType;
 import protocolsupport.utils.recyclable.RecyclableCollection;
 import protocolsupport.utils.recyclable.RecyclableSingletonList;
 
@@ -15,7 +15,7 @@ public class EntityTeleport extends MiddleEntityTeleport {
 	public RecyclableCollection<ClientBoundPacketData> toData(ProtocolVersion version) {
 		WatchedEntity wentity = cache.getWatchedEntity(entityId);
 		y *= 32;
-		if ((wentity != null) && ((wentity.getType() == SpecificRemapper.TNT) || (wentity.getType() == SpecificRemapper.FALLING_OBJECT))) {
+		if ((wentity != null) && ((wentity.getType() == WatchedType.TNT) || (wentity.getType() == WatchedType.FALLING_OBJECT))) {
 			y += 16;
 		}
 		ClientBoundPacketData serializer = ClientBoundPacketData.create(ClientBoundPacket.PLAY_ENTITY_TELEPORT_ID, version);

--- a/src/protocolsupport/protocol/typeremapper/watchedentity/WatchedDataRemapper.java
+++ b/src/protocolsupport/protocol/typeremapper/watchedentity/WatchedDataRemapper.java
@@ -8,6 +8,7 @@ import protocolsupport.protocol.typeremapper.watchedentity.remapper.MappingEntry
 import protocolsupport.protocol.typeremapper.watchedentity.remapper.SpecificRemapper;
 import protocolsupport.protocol.typeremapper.watchedentity.remapper.value.ValueRemapper;
 import protocolsupport.protocol.typeremapper.watchedentity.types.WatchedEntity;
+import protocolsupport.protocol.typeremapper.watchedentity.types.WatchedType;
 import protocolsupport.protocol.utils.datawatcher.DataWatcherObject;
 import protocolsupport.protocol.utils.datawatcher.objects.DataWatcherObjectByte;
 import protocolsupport.utils.Utils;
@@ -23,7 +24,7 @@ public class WatchedDataRemapper {
 			return EMPTY_MAP;
 		}
 		//copy active hand meta to base flags index 4
-		if (entity.getType() == SpecificRemapper.PLAYER) {
+		if (entity.getType() == WatchedType.PLAYER) {
 			DataWatcherObject<?> baseflags = originaldata.get(0);
 			if (baseflags != null) {
 				if (baseflags.getValue() instanceof Number) {
@@ -54,7 +55,7 @@ public class WatchedDataRemapper {
 		}
 		//registry based remap
 		TIntObjectHashMap<DataWatcherObject<?>> transformed = new TIntObjectHashMap<>();
-		SpecificRemapper stype = entity.getType();
+		SpecificRemapper stype = SpecificRemapper.fromWatchedType(entity.getType());
 		for (MappingEntry entry : stype.getRemaps(to)) {
 			DataWatcherObject<?> object = originaldata.get(entry.getIdFrom());
 			if (object != null) {
@@ -74,7 +75,7 @@ public class WatchedDataRemapper {
 
 	public static class MetadataRemapException extends RuntimeException {
 
-		public MetadataRemapException(int index, int entityId, SpecificRemapper type, ProtocolVersion to, Exception e) {
+		public MetadataRemapException(int index, int entityId, WatchedType type, ProtocolVersion to, Exception e) {
 			super(Utils.exceptionMessage(
 				"Unable to remap entity metadata",
 				String.format("Metadata index: %d", index),

--- a/src/protocolsupport/protocol/typeremapper/watchedentity/remapper/SpecificRemapper.java
+++ b/src/protocolsupport/protocol/typeremapper/watchedentity/remapper/SpecificRemapper.java
@@ -757,9 +757,9 @@ public enum SpecificRemapper {
 	}
 	
 	public static SpecificRemapper fromWatchedType(WatchedType type){
-		if(type.getEType() == protocolsupport.protocol.typeremapper.watchedentity.types.WatchedType.EType.MOB){
+		if (type.getEType() == WatchedType.EType.MOB) {
 			return getMobByTypeId(type.getTypeId());
-		}else if(type.getEType() == protocolsupport.protocol.typeremapper.watchedentity.types.WatchedType.EType.OBJECT){
+		} else if (type.getEType() == WatchedType.EType.OBJECT) {
 			return getObjectByTypeId(type.getTypeId());
 		}
 		return SpecificRemapper.NONE;

--- a/src/protocolsupport/protocol/typeremapper/watchedentity/remapper/SpecificRemapper.java
+++ b/src/protocolsupport/protocol/typeremapper/watchedentity/remapper/SpecificRemapper.java
@@ -16,6 +16,7 @@ import protocolsupport.protocol.typeremapper.watchedentity.remapper.value.ValueR
 import protocolsupport.protocol.typeremapper.watchedentity.remapper.value.ValueRemapperNumberToInt;
 import protocolsupport.protocol.typeremapper.watchedentity.remapper.value.ValueRemapperNumberToShort;
 import protocolsupport.protocol.typeremapper.watchedentity.remapper.value.ValueRemapperStringClamp;
+import protocolsupport.protocol.typeremapper.watchedentity.types.WatchedType;
 import protocolsupport.protocol.utils.datawatcher.DataWatcherObject;
 import protocolsupport.protocol.utils.datawatcher.objects.DataWatcherObjectBlockState;
 import protocolsupport.protocol.utils.datawatcher.objects.DataWatcherObjectBoolean;
@@ -753,6 +754,15 @@ public enum SpecificRemapper {
 			return SpecificRemapper.NONE;
 		}
 		return MOB_BY_TYPE_ID[mobTypeId];
+	}
+	
+	public static SpecificRemapper fromWatchedType(WatchedType type){
+		if(type.getEType() == protocolsupport.protocol.typeremapper.watchedentity.types.WatchedType.EType.MOB){
+			return getMobByTypeId(type.getTypeId());
+		}else if(type.getEType() == protocolsupport.protocol.typeremapper.watchedentity.types.WatchedType.EType.OBJECT){
+			return getObjectByTypeId(type.getTypeId());
+		}
+		return SpecificRemapper.NONE;
 	}
 
 	private final EType etype;

--- a/src/protocolsupport/protocol/typeremapper/watchedentity/types/WatchedEntity.java
+++ b/src/protocolsupport/protocol/typeremapper/watchedentity/types/WatchedEntity.java
@@ -1,7 +1,5 @@
 package protocolsupport.protocol.typeremapper.watchedentity.types;
 
-import protocolsupport.protocol.typeremapper.watchedentity.remapper.SpecificRemapper;
-
 public abstract class WatchedEntity {
 
 	private final int id;
@@ -14,7 +12,7 @@ public abstract class WatchedEntity {
 		return id;
 	}
 
-	public abstract SpecificRemapper getType();
+	public abstract WatchedType getType();
 
 	@Override
 	public String toString() {

--- a/src/protocolsupport/protocol/typeremapper/watchedentity/types/WatchedLiving.java
+++ b/src/protocolsupport/protocol/typeremapper/watchedentity/types/WatchedLiving.java
@@ -1,19 +1,16 @@
 package protocolsupport.protocol.typeremapper.watchedentity.types;
 
-import protocolsupport.protocol.typeremapper.watchedentity.remapper.SpecificRemapper;
-
-
 public class WatchedLiving extends WatchedEntity {
 
-	private final SpecificRemapper stype;
+	private final WatchedType stype;
 
 	public WatchedLiving(int id, int type) {
 		super(id);
-		stype = SpecificRemapper.getMobByTypeId(type);
+		stype = WatchedType.getMobByTypeId(type);
 	}
 
 	@Override
-	public SpecificRemapper getType() {
+	public WatchedType getType() {
 		return stype;
 	}
 

--- a/src/protocolsupport/protocol/typeremapper/watchedentity/types/WatchedObject.java
+++ b/src/protocolsupport/protocol/typeremapper/watchedentity/types/WatchedObject.java
@@ -1,19 +1,18 @@
 package protocolsupport.protocol.typeremapper.watchedentity.types;
 
-import protocolsupport.protocol.typeremapper.watchedentity.remapper.SpecificRemapper;
 
 
 public class WatchedObject extends WatchedEntity {
 
-	private final SpecificRemapper stype;
+	private final WatchedType stype;
 
 	public WatchedObject(int id, int type) {
 		super(id);
-		stype = SpecificRemapper.getObjectByTypeId(type);
+		stype = WatchedType.getObjectByTypeId(type);
 	}
 
 	@Override
-	public SpecificRemapper getType() {
+	public WatchedType getType() {
 		return stype;
 	}
 

--- a/src/protocolsupport/protocol/typeremapper/watchedentity/types/WatchedPlayer.java
+++ b/src/protocolsupport/protocol/typeremapper/watchedentity/types/WatchedPlayer.java
@@ -1,8 +1,5 @@
 package protocolsupport.protocol.typeremapper.watchedentity.types;
 
-import protocolsupport.protocol.typeremapper.watchedentity.remapper.SpecificRemapper;
-
-
 public class WatchedPlayer extends WatchedEntity {
 
 	public WatchedPlayer(int id) {
@@ -10,8 +7,8 @@ public class WatchedPlayer extends WatchedEntity {
 	}
 
 	@Override
-	public SpecificRemapper getType() {
-		return SpecificRemapper.PLAYER;
+	public WatchedType getType() {
+		return WatchedType.PLAYER;
 	}
 
 }

--- a/src/protocolsupport/protocol/typeremapper/watchedentity/types/WatchedType.java
+++ b/src/protocolsupport/protocol/typeremapper/watchedentity/types/WatchedType.java
@@ -8,6 +8,11 @@ import org.bukkit.entity.EntityType;
  * All the types network entities can be.
  */
 public enum WatchedType {
+	
+    //=====================================================\\
+    //					  Watched Types					   \\
+    //=====================================================\\
+	
 	NONE(EType.NONE, -1),
 	ENTITY(EType.NONE, -1),
 	LIVING(EType.NONE, -1, WatchedType.ENTITY),
@@ -103,17 +108,18 @@ public enum WatchedType {
 	DRAGON_FIREBALL(EType.OBJECT, EntityType.DRAGON_FIREBALL, ENTITY),
 	EVOCATOR_FANGS(EType.OBJECT, EntityType.EVOKER_FANGS, ENTITY);
 	
+    //=====================================================\\
+    //					Object Values					   \\
+    //=====================================================\\
+	
 	private final EType etype;
 	private final int typeId;
-	private WatchedType superType;
-	
-	private static final WatchedType[] OBJECT_BY_TYPE_ID = new WatchedType[256];
-	private static final WatchedType[] MOB_BY_TYPE_ID = new WatchedType[256];
+	private final WatchedType superType;
 
 	/***
 	 * @return the type's parent.
 	 */
-	public WatchedType getSuperType(){
+	public WatchedType getSuperType() {
 		return superType;
 	}
 	
@@ -130,6 +136,54 @@ public enum WatchedType {
 	public EType getEType() {
 		return etype;
 	}
+	
+	/***
+	 * Checks whether the WatchedEntity is the same as <strong>type</strong> or a some child of <strong>type</strong>.
+	 * @param type
+	 * @return true, if there is a connection
+	 */
+	public boolean isOfType(WatchedType type) {
+		return (type == this || (getSuperType() != null && getSuperType().isOfType(type)));
+	}
+	
+	/***
+	 * Entities can be either a mob or an object.
+	 */
+	public enum EType {
+		NONE, OBJECT, MOB
+	}
+	
+    //=====================================================\\
+    //					Static Values					   \\
+    //=====================================================\\
+	
+	private static final WatchedType[] OBJECT_BY_TYPE_ID = new WatchedType[256];
+	private static final WatchedType[] MOB_BY_TYPE_ID = new WatchedType[256];
+	
+	//Fill static values.
+	static {
+		Arrays.fill(OBJECT_BY_TYPE_ID, WatchedType.NONE);
+		Arrays.fill(MOB_BY_TYPE_ID, WatchedType.NONE);
+		for (WatchedType type : values()) {
+			if (type.typeId != -1){
+				switch (type.etype) {
+					case OBJECT: {
+						OBJECT_BY_TYPE_ID[type.typeId] = type;
+						break;
+					}
+					case MOB: {
+						MOB_BY_TYPE_ID[type.typeId] = type;
+						break;
+					}
+					default: {
+						break;
+					}
+				}
+			}
+		}
+	}
+	
+	public static void init() { }
 	
 	/***
 	 * Gets the WatchedType for an object using it's ID.
@@ -154,70 +208,28 @@ public enum WatchedType {
 		}
 		return MOB_BY_TYPE_ID[mobTypeId];
 	}
-	
-	static {
-		Arrays.fill(OBJECT_BY_TYPE_ID, WatchedType.NONE);
-		Arrays.fill(MOB_BY_TYPE_ID, WatchedType.NONE);
-		for (WatchedType type : values()) {
-			if(type.typeId != -1){
-				switch (type.etype) {
-				case OBJECT: {
-					OBJECT_BY_TYPE_ID[type.typeId] = type;
-					break;
-				}
-				case MOB: {
-					MOB_BY_TYPE_ID[type.typeId] = type;
-					break;
-				}
-				default: {
-					break;
-				}
-			}
-			}
-		}
-	}
-	
-	public static void init() {
-	}
-	
-	/***
-	 * Entities can be either a mob or an object.
-	 */
-	public enum EType {
-		NONE, OBJECT, MOB
-	}
-	
-	/***
-	 * Checks whether the WatchedEntity is the same as <strong>type</strong> or a some child of <strong>type</strong>.
-	 * @param type
-	 * @return true, if there is a connection
-	 */
-	public boolean isOfType(WatchedType type){
-		return type == this || (getSuperType() != null && getSuperType().isOfType(type));
-	}
 		
     //=====================================================\\
     //					Constructors					   \\
     //=====================================================\\
 	
-	WatchedType(EType etype, int typeId) {
+	WatchedType(EType etype, int typeId, WatchedType superType) {
 		this.etype = etype;
 		this.typeId = typeId;
-		this.superType = null;
+		this.superType = superType;
 	}
 	
 	@SuppressWarnings("deprecation")
-	WatchedType(EType etype, EntityType type) {
-		this(etype, type.getTypeId());
-	}
-	
-	WatchedType(EType etype, int typeId, WatchedType superType) {
-		this(etype, typeId);
-		this.superType = superType;
-	}
-	
 	WatchedType(EType etype, EntityType type, WatchedType superType) {
-		this(etype, type);
-		this.superType = superType;
+		this(etype, type.getTypeId(), superType);
 	}
+	
+	WatchedType(EType etype, int typeId) {
+		this(etype, typeId, null);
+	}
+	
+	WatchedType(EType etype, EntityType type) {
+		this(etype, type, null);
+	}
+	
 }

--- a/src/protocolsupport/protocol/typeremapper/watchedentity/types/WatchedType.java
+++ b/src/protocolsupport/protocol/typeremapper/watchedentity/types/WatchedType.java
@@ -1,0 +1,223 @@
+package protocolsupport.protocol.typeremapper.watchedentity.types;
+
+import java.util.Arrays;
+
+import org.bukkit.entity.EntityType;
+
+/***
+ * All the types network entities can be.
+ */
+public enum WatchedType {
+	NONE(EType.NONE, -1),
+	ENTITY(EType.NONE, -1),
+	LIVING(EType.NONE, -1, WatchedType.ENTITY),
+	INSENTIENT(EType.NONE, -1, WatchedType.LIVING),
+	PLAYER(EType.NONE, -1, WatchedType.LIVING),
+	AGEABLE(EType.NONE, -1, WatchedType.INSENTIENT),
+	TAMEABLE(EType.NONE, -1, WatchedType.AGEABLE),
+	ARMOR_STAND(EType.NONE, -1, WatchedType.LIVING),
+	COW(EType.MOB, EntityType.COW, WatchedType.AGEABLE),
+	MUSHROOM_COW(EType.MOB, EntityType.MUSHROOM_COW, WatchedType.COW),
+	CHICKEN(EType.MOB, EntityType.CHICKEN, WatchedType.AGEABLE),
+	SQUID(EType.MOB, EntityType.SQUID, WatchedType.INSENTIENT),
+	BASE_HORSE(EType.NONE, -1, WatchedType.AGEABLE),
+	BASE_MINECART(EType.NONE, -1, WatchedType.ENTITY),
+	BATTLE_HORSE(EType.NONE, -1, BASE_HORSE),
+	CARGO_HORSE(EType.NONE, -1, BASE_HORSE),
+	COMMON_HORSE(EType.MOB, EntityType.HORSE, BATTLE_HORSE),
+	ZOMBIE_HORSE(EType.MOB, EntityType.ZOMBIE_HORSE, BATTLE_HORSE),
+	SKELETON_HORSE(EType.MOB, EntityType.SKELETON_HORSE, BATTLE_HORSE),
+	DONKEY(EType.MOB, EntityType.DONKEY, CARGO_HORSE),
+	MULE(EType.MOB, EntityType.MULE, CARGO_HORSE),
+	LAMA(EType.MOB, EntityType.LLAMA, CARGO_HORSE),
+	BAT(EType.MOB, EntityType.BAT, INSENTIENT),
+	OCELOT(EType.MOB, EntityType.OCELOT, TAMEABLE),
+	WOLF(EType.MOB, EntityType.WOLF, TAMEABLE),
+	PIG(EType.MOB, EntityType.PIG, AGEABLE),
+	RABBIT(EType.MOB, EntityType.RABBIT, AGEABLE),
+	SHEEP(EType.MOB, EntityType.SHEEP, AGEABLE),
+	POLAR_BEAR(EType.MOB, EntityType.POLAR_BEAR, AGEABLE),
+	VILLAGER(EType.MOB, EntityType.VILLAGER, AGEABLE),
+	ENDERMAN(EType.MOB, EntityType.ENDERMAN, INSENTIENT),
+	GIANT(EType.MOB, EntityType.GIANT, INSENTIENT),
+	SILVERFISH(EType.MOB, EntityType.SILVERFISH, INSENTIENT),
+	ENDERMITE(EType.MOB, EntityType.ENDERMITE, INSENTIENT),
+	ENDER_DRAGON(EType.MOB, EntityType.ENDER_DRAGON, INSENTIENT),
+	SNOWMAN(EType.MOB, EntityType.SNOWMAN, INSENTIENT),
+	ZOMBIE(EType.MOB, EntityType.ZOMBIE, INSENTIENT),
+	ZOMBIE_VILLAGER(EType.MOB, EntityType.ZOMBIE_VILLAGER, ZOMBIE),
+	HUSK(EType.MOB, EntityType.HUSK, ZOMBIE),
+	ZOMBIE_PIGMAN(EType.MOB, EntityType.PIG_ZOMBIE, ZOMBIE),
+	BLAZE(EType.MOB, EntityType.BLAZE, INSENTIENT),
+	SPIDER(EType.MOB, EntityType.SPIDER, LIVING),
+	CAVE_SPIDER(EType.MOB, EntityType.CAVE_SPIDER, SPIDER),
+	CREEPER(EType.MOB, EntityType.CREEPER, INSENTIENT),
+	GHAST(EType.MOB, EntityType.GHAST, INSENTIENT),
+	SLIME(EType.MOB, EntityType.SLIME, INSENTIENT),
+	MAGMA_CUBE(EType.MOB, EntityType.MAGMA_CUBE, SLIME),
+	BASE_SKELETON(EType.NONE, -1, INSENTIENT),
+	SKELETON(EType.MOB, EntityType.SKELETON, BASE_SKELETON),
+	WITHER_SKELETON(EType.MOB, EntityType.WITHER_SKELETON, BASE_SKELETON),
+	STRAY(EType.MOB, EntityType.STRAY, BASE_SKELETON),
+	WITCH(EType.MOB, EntityType.WITCH, INSENTIENT),
+	IRON_GOLEM(EType.MOB, EntityType.IRON_GOLEM, INSENTIENT),
+	SHULKER(EType.MOB, EntityType.SHULKER, INSENTIENT),
+	WITHER(EType.MOB, EntityType.WITHER, INSENTIENT),
+	GUARDIAN(EType.MOB, EntityType.GUARDIAN, INSENTIENT),
+	ELDER_GUARDIAN(EType.MOB, EntityType.ELDER_GUARDIAN, GUARDIAN),
+	VINDICATOR(EType.MOB, EntityType.VINDICATOR, INSENTIENT),
+	EVOKER(EType.MOB, EntityType.EVOKER, INSENTIENT),
+	VEX(EType.MOB, EntityType.VEX, INSENTIENT),
+	ARMOR_STAND_MOB(EType.MOB, EntityType.ARMOR_STAND, ARMOR_STAND),
+	BOAT(EType.OBJECT, EntityType.BOAT),
+	TNT(EType.OBJECT, EntityType.PRIMED_TNT, ENTITY),
+	SNOWBALL(EType.OBJECT, EntityType.SNOWBALL, ENTITY),
+	EGG(EType.OBJECT, EntityType.EGG, ENTITY),
+	FIREBALL(EType.OBJECT, EntityType.FIREBALL, ENTITY),
+	FIRECHARGE(EType.OBJECT, EntityType.SMALL_FIREBALL, ENTITY),
+	ENDERPEARL(EType.OBJECT, EntityType.ENDER_PEARL, ENTITY),
+	WITHER_SKULL(EType.OBJECT, EntityType.WITHER_SKULL, FIREBALL),
+	FALLING_OBJECT(EType.OBJECT, EntityType.FALLING_BLOCK, ENTITY),
+	ENDEREYE(EType.OBJECT, EntityType.ENDER_SIGNAL, ENTITY),
+	POTION(EType.OBJECT, EntityType.SPLASH_POTION, ENTITY),
+	EXP_BOTTLE(EType.OBJECT, EntityType.THROWN_EXP_BOTTLE, ENTITY),
+	LEASH_KNOT(EType.OBJECT, EntityType.LEASH_HITCH, ENTITY),
+	FISHING_FLOAT(EType.OBJECT, EntityType.FISHING_HOOK, ENTITY),
+	ITEM(EType.OBJECT, EntityType.DROPPED_ITEM, ENTITY),
+	MINECART(EType.OBJECT, EntityType.MINECART, BASE_MINECART),
+	MINECART_CHEST(EType.OBJECT, EntityType.MINECART_CHEST, BASE_MINECART),
+	MINECART_COMMAND(EType.OBJECT, EntityType.MINECART_COMMAND, BASE_MINECART),
+	MINECART_FURNACE(EType.OBJECT, EntityType.MINECART_FURNACE, BASE_MINECART),
+	MINECART_HOPPER(EType.OBJECT, EntityType.MINECART_HOPPER, BASE_MINECART),
+	MINECART_MOB_SPAWNER(EType.OBJECT, EntityType.MINECART_MOB_SPAWNER, BASE_MINECART),
+	MINECART_TNT(EType.OBJECT, EntityType.MINECART_TNT, BASE_MINECART),
+	ARROW(EType.OBJECT, EntityType.ARROW, ENTITY),
+	SPECTRAL_ARROW(EType.OBJECT, EntityType.SPECTRAL_ARROW, ARROW),
+	TIPPED_ARROW(EType.OBJECT, EntityType.TIPPED_ARROW, ARROW),
+	FIREWORK(EType.OBJECT, EntityType.FIREWORK, ENTITY),
+	ITEM_FRAME(EType.OBJECT, EntityType.ITEM_FRAME, ENTITY),
+	ENDER_CRYSTAL(EType.OBJECT, EntityType.ENDER_CRYSTAL, ENTITY),
+	ARMOR_STAND_OBJECT(EType.OBJECT, EntityType.ARMOR_STAND, ARMOR_STAND),
+	AREA_EFFECT_CLOUD(EType.OBJECT, EntityType.AREA_EFFECT_CLOUD, ENTITY),
+	SHULKER_BULLET(EType.OBJECT, EntityType.SHULKER_BULLET, ENTITY),
+	DRAGON_FIREBALL(EType.OBJECT, EntityType.DRAGON_FIREBALL, ENTITY),
+	EVOCATOR_FANGS(EType.OBJECT, EntityType.EVOKER_FANGS, ENTITY);
+	
+	private final EType etype;
+	private final int typeId;
+	private WatchedType superType;
+	
+	private static final WatchedType[] OBJECT_BY_TYPE_ID = new WatchedType[256];
+	private static final WatchedType[] MOB_BY_TYPE_ID = new WatchedType[256];
+
+	/***
+	 * @return the type's parent.
+	 */
+	public WatchedType getSuperType(){
+		return superType;
+	}
+	
+	/***
+	 * @return the typeId.
+	 */
+	public int getTypeId() {
+		return typeId;
+	}
+	
+	/***
+	 * @return the type's eType.
+	 */
+	public EType getEType() {
+		return etype;
+	}
+	
+	/***
+	 * Gets the WatchedType for an object using it's ID.
+	 * @param objectTypeId
+	 * @return the corresponding WatchedType
+	 */
+	public static WatchedType getObjectByTypeId(int objectTypeId) {
+		if (objectTypeId < 0 || objectTypeId >= OBJECT_BY_TYPE_ID.length) {
+			return WatchedType.NONE;
+		}
+		return OBJECT_BY_TYPE_ID[objectTypeId];
+	}
+
+	/***
+	 * Gets the WatchedType for a mob using it's ID.
+	 * @param mobTypeId
+	 * @return the corresponding WatchedType
+	 */
+	public static WatchedType getMobByTypeId(int mobTypeId) {
+		if (mobTypeId < 0 || mobTypeId >= MOB_BY_TYPE_ID.length) {
+			return WatchedType.NONE;
+		}
+		return MOB_BY_TYPE_ID[mobTypeId];
+	}
+	
+	static {
+		Arrays.fill(OBJECT_BY_TYPE_ID, WatchedType.NONE);
+		Arrays.fill(MOB_BY_TYPE_ID, WatchedType.NONE);
+		for (WatchedType type : values()) {
+			if(type.typeId != -1){
+				switch (type.etype) {
+				case OBJECT: {
+					OBJECT_BY_TYPE_ID[type.typeId] = type;
+					break;
+				}
+				case MOB: {
+					MOB_BY_TYPE_ID[type.typeId] = type;
+					break;
+				}
+				default: {
+					break;
+				}
+			}
+			}
+		}
+	}
+	
+	public static void init() {
+	}
+	
+	/***
+	 * Entities can be either a mob or an object.
+	 */
+	public enum EType {
+		NONE, OBJECT, MOB
+	}
+	
+	/***
+	 * Checks whether the WatchedEntity is the same as <strong>type</strong> or a some child of <strong>type</strong>.
+	 * @param type
+	 * @return true, if there is a connection
+	 */
+	public boolean isOfType(WatchedType type){
+		return type == this || (getSuperType() != null && getSuperType().isOfType(type));
+	}
+		
+    //=====================================================\\
+    //					Constructors					   \\
+    //=====================================================\\
+	
+	WatchedType(EType etype, int typeId) {
+		this.etype = etype;
+		this.typeId = typeId;
+		this.superType = null;
+	}
+	
+	@SuppressWarnings("deprecation")
+	WatchedType(EType etype, EntityType type) {
+		this(etype, type.getTypeId());
+	}
+	
+	WatchedType(EType etype, int typeId, WatchedType superType) {
+		this(etype, typeId);
+		this.superType = superType;
+	}
+	
+	WatchedType(EType etype, EntityType type, WatchedType superType) {
+		this(etype, type);
+		this.superType = superType;
+	}
+}

--- a/src/protocolsupport/protocol/typeremapper/watchedentity/types/WatchedType.java
+++ b/src/protocolsupport/protocol/typeremapper/watchedentity/types/WatchedType.java
@@ -8,11 +8,6 @@ import org.bukkit.entity.EntityType;
  * All the types network entities can be.
  */
 public enum WatchedType {
-	
-    //=====================================================\\
-    //					  Watched Types					   \\
-    //=====================================================\\
-	
 	NONE(EType.NONE, -1),
 	ENTITY(EType.NONE, -1),
 	LIVING(EType.NONE, -1, WatchedType.ENTITY),
@@ -108,10 +103,6 @@ public enum WatchedType {
 	DRAGON_FIREBALL(EType.OBJECT, EntityType.DRAGON_FIREBALL, ENTITY),
 	EVOCATOR_FANGS(EType.OBJECT, EntityType.EVOKER_FANGS, ENTITY);
 	
-    //=====================================================\\
-    //					Object Values					   \\
-    //=====================================================\\
-	
 	private final EType etype;
 	private final int typeId;
 	private final WatchedType superType;
@@ -153,14 +144,10 @@ public enum WatchedType {
 		NONE, OBJECT, MOB
 	}
 	
-    //=====================================================\\
-    //					Static Values					   \\
-    //=====================================================\\
-	
 	private static final WatchedType[] OBJECT_BY_TYPE_ID = new WatchedType[256];
 	private static final WatchedType[] MOB_BY_TYPE_ID = new WatchedType[256];
 	
-	//Fill static values.
+	//Fill the static values.
 	static {
 		Arrays.fill(OBJECT_BY_TYPE_ID, WatchedType.NONE);
 		Arrays.fill(MOB_BY_TYPE_ID, WatchedType.NONE);
@@ -208,10 +195,6 @@ public enum WatchedType {
 		}
 		return MOB_BY_TYPE_ID[mobTypeId];
 	}
-		
-    //=====================================================\\
-    //					Constructors					   \\
-    //=====================================================\\
 	
 	WatchedType(EType etype, int typeId, WatchedType superType) {
 		this.etype = etype;


### PR DESCRIPTION
Already makes things less awkward.

For now the SpecificRemapper just transforms from WatchedType crudely and the metadata remapper still uses the SpecificRemapper, but that remapper has to be changed anyway.

I just copied most of the values of the SpecificRemapper, and added a few bukkit types.