### PR TITLE
Implement "SpawnExpOrb" packet

### DIFF
--- a/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_pe/SpawnExpOrb.java
+++ b/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_pe/SpawnExpOrb.java
@@ -1,0 +1,17 @@
+package protocolsupport.protocol.packet.middleimpl.clientbound.play.v_pe;
+
+import protocolsupport.api.ProtocolVersion;
+import protocolsupport.protocol.packet.middle.clientbound.play.MiddleSpawnExpOrb;
+import protocolsupport.protocol.packet.middleimpl.ClientBoundPacketData;
+import protocolsupport.utils.recyclable.RecyclableCollection;
+import protocolsupport.utils.recyclable.RecyclableSingletonList;
+
+public class SpawnExpOrb extends MiddleSpawnExpOrb {
+
+	@Override
+	public RecyclableCollection<ClientBoundPacketData> toData(ProtocolVersion version) {
+		// TODO: When metadata is implemented, set the exp count in the exp orb metadata!
+		return RecyclableSingletonList.create(SpawnGlobal.create(version, entityId, x, y, z, 69));
+	}
+
+}

--- a/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_pe/SpawnGlobal.java
+++ b/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_pe/SpawnGlobal.java
@@ -13,10 +13,14 @@ public class SpawnGlobal extends MiddleSpawnGlobal {
 
 	@Override
 	public RecyclableCollection<ClientBoundPacketData> toData(ProtocolVersion version) {
+		return RecyclableSingletonList.create(SpawnGlobal.create(version, entityId, x, y, z, 93));
+	}
+	
+	protected static ClientBoundPacketData create(ProtocolVersion version, int entityId, double x, double y, double z, int entityType) {
 		ClientBoundPacketData serializer = ClientBoundPacketData.create(PEPacketIDs.SPAWN_ENTITY, version);
 		VarNumberSerializer.writeSVarLong(serializer, entityId);
 		VarNumberSerializer.writeVarLong(serializer, entityId);
-		VarNumberSerializer.writeVarInt(serializer, 93); //Lightning is always entity 93. No remap. No worries.
+		VarNumberSerializer.writeVarInt(serializer, entityType);
 		MiscSerializer.writeLFloat(serializer, (float) x);
 		MiscSerializer.writeLFloat(serializer, (float) y);
 		MiscSerializer.writeLFloat(serializer, (float) z);
@@ -28,6 +32,6 @@ public class SpawnGlobal extends MiddleSpawnGlobal {
 		VarNumberSerializer.writeVarInt(serializer, 0); //attributes, not used
 		VarNumberSerializer.writeVarInt(serializer, 0); //metadata, not used
 		VarNumberSerializer.writeVarInt(serializer, 0); //links, not used
-		return RecyclableSingletonList.create(serializer);
+		return serializer;
 	}
 }

--- a/src/protocolsupport/protocol/pipeline/version/v_pe/PEPacketEncoder.java
+++ b/src/protocolsupport/protocol/pipeline/version/v_pe/PEPacketEncoder.java
@@ -28,6 +28,7 @@ import protocolsupport.protocol.packet.middleimpl.clientbound.play.v_pe.Respawn;
 import protocolsupport.protocol.packet.middleimpl.clientbound.play.v_pe.ServerDifficulty;
 import protocolsupport.protocol.packet.middleimpl.clientbound.play.v_pe.SetExperience;
 import protocolsupport.protocol.packet.middleimpl.clientbound.play.v_pe.SetHealth;
+import protocolsupport.protocol.packet.middleimpl.clientbound.play.v_pe.SpawnExpOrb;
 import protocolsupport.protocol.packet.middleimpl.clientbound.play.v_pe.SpawnGlobal;
 import protocolsupport.protocol.packet.middleimpl.clientbound.play.v_pe.SpawnLiving;
 import protocolsupport.protocol.packet.middleimpl.clientbound.play.v_pe.SpawnNamed;
@@ -78,6 +79,7 @@ public class PEPacketEncoder extends AbstractLegacyPacketEncoder {
 		registry.register(NetworkState.PLAY, ClientBoundPacket.PLAY_SPAWN_WEATHER_ID, SpawnGlobal.class);
 		registry.register(NetworkState.PLAY, ClientBoundPacket.PLAY_ABILITIES_ID, PlayerAbilities.class);
 		registry.register(NetworkState.PLAY, ClientBoundPacket.PLAY_TITLE_ID, Title.class);
+		registry.register(NetworkState.PLAY, ClientBoundPacket.PLAY_SPAWN_EXP_ORB_ID, SpawnExpOrb.class);
 	}
 
 	public PEPacketEncoder(Connection connection, NetworkDataCache storage) {


### PR DESCRIPTION
![https://cdn.discordapp.com/attachments/286106780189065216/325280597113044992/Screenshot_20170616-112843.png](https://cdn.discordapp.com/attachments/286106780189065216/325280597113044992/Screenshot_20170616-112843.png)

To avoid code redundancy I created a static method in SpawnGlobal since the code used in XP orbs and lightning are the same. (except the entity type)

However this may or may not be a problem when entity metadata is implemented. (since, according to @DaMatrix, the XP count for XP orbs are sent in the metadata (instead of PC where it is sent in the SpawnExpOrb packet))