### PR TITLE
Update NetworkEntity.java

### DIFF
--- a/src/protocolsupport/protocol/utils/types/NetworkEntity.java
+++ b/src/protocolsupport/protocol/utils/types/NetworkEntity.java
@@ -43,6 +43,10 @@ public class NetworkEntity {
 	public NetworkEntityType getType() {
 		return type;
 	}
+	
+	public boolean isOfType(NetworkEntityType type) {
+		return type.isOfType(type);
+	}
 
 	private final DataCache cache = new DataCache();
 


### PR DESCRIPTION
It sometimes makes more sense to use isOfType(x) instead of .getType == x. This would be used when checking against certain groups that are extended on by other dataTypes. When entity is spider: `entity.isOfType(NetworkEntityType.INSENTIENT) = true` while `entity.getType == NetworkEntityType.INSENTIENT = false` Currently this check can be done using entity.getType.isOfType(x) (As it does come in handy to check if a certain type is of another type) but it made sense to also include it on the entity's level.