### PR TITLE
/protocolsupport command improvements

### DIFF
--- a/resources/plugin.yml
+++ b/resources/plugin.yml
@@ -7,4 +7,4 @@ commands:
   protocolsupport:
     description: All ProtocolSupport commands
     aliases: ps
-    usage: Invalid command
+    usage: '/protocolsupport [buildinfo|list|debug|leakdetector|connections]'

--- a/src/protocolsupport/ProtocolSupport.java
+++ b/src/protocolsupport/ProtocolSupport.java
@@ -89,6 +89,11 @@ public class ProtocolSupport extends JavaPlugin {
 			getLogger().log(Level.SEVERE, "Error when loading, make sure you are using supported server version", t);
 			Bukkit.shutdown();
 		}
+
+		getConfig().addDefault("expose-plugin", true);
+		getConfig().addDefault("list-only-relevant-versions", false);
+		getConfig().options().copyDefaults(true);
+		saveConfig();
 	}
 
 	@Override

--- a/src/protocolsupport/ProtocolSupport.java
+++ b/src/protocolsupport/ProtocolSupport.java
@@ -89,11 +89,6 @@ public class ProtocolSupport extends JavaPlugin {
 			getLogger().log(Level.SEVERE, "Error when loading, make sure you are using supported server version", t);
 			Bukkit.shutdown();
 		}
-
-		getConfig().addDefault("expose-plugin", true);
-		getConfig().addDefault("list-only-relevant-versions", false);
-		getConfig().options().copyDefaults(true);
-		saveConfig();
 	}
 
 	@Override

--- a/src/protocolsupport/commands/CommandHandler.java
+++ b/src/protocolsupport/commands/CommandHandler.java
@@ -29,7 +29,7 @@ public class CommandHandler implements CommandExecutor, TabCompleter {
 	@Override
 	public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
 		if (!sender.hasPermission("protocolsupport.admin")) {
-			sender.sendMessage("Unknown command. Type \"/help\" for help.");
+			sender.sendMessage(ChatColor.RED + "You have no power here!");
 			return true;
 		}
 		else if(args.length == 1 || args.length == 2) {

--- a/src/protocolsupport/commands/CommandHandler.java
+++ b/src/protocolsupport/commands/CommandHandler.java
@@ -29,10 +29,10 @@ public class CommandHandler implements CommandExecutor, TabCompleter {
 	@Override
 	public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
 		if (!sender.hasPermission("protocolsupport.admin")) {
-			sender.sendMessage(plugin.getConfig().getBoolean("expose-plugin") ? ChatColor.RED + "You have no power here!" : "Unknown command. Type \"/help\" for help.");
+			sender.sendMessage("Unknown command. Type \"/help\" for help.");
 			return true;
 		}
-		else if(args.length == 1) {
+		else if(args.length == 1 || args.length == 2) {
 			if (args[0].equalsIgnoreCase("buildinfo")) {
 				sender.sendMessage(ChatColor.GOLD.toString() + plugin.getBuildInfo());
 				return true;
@@ -41,7 +41,7 @@ public class CommandHandler implements CommandExecutor, TabCompleter {
 				for (ProtocolVersion version : ProtocolVersion.values()) {
 					if (version.isSupported()) {
 						String res = getPlayersStringForProtocol(version);
-						if(res.length() > 0 || !plugin.getConfig().getBoolean("list-only-relevant-versions"))
+						if(res.length() > 0 || (args.length == 2 && (args[1].equalsIgnoreCase("v") || args[1].equalsIgnoreCase("verbose"))))
 							sender.sendMessage(ChatColor.GOLD+"["+version.getName()+"]: "+ChatColor.GREEN+res);
 					}
 				}

--- a/src/protocolsupport/commands/CommandHandler.java
+++ b/src/protocolsupport/commands/CommandHandler.java
@@ -29,48 +29,53 @@ public class CommandHandler implements CommandExecutor, TabCompleter {
 	@Override
 	public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
 		if (!sender.hasPermission("protocolsupport.admin")) {
-			sender.sendMessage(ChatColor.RED + "You have no power here!");
+			sender.sendMessage(plugin.getConfig().getBoolean("expose-plugin") ? ChatColor.RED + "You have no power here!" : "Unknown command. Type \"/help\" for help.");
 			return true;
 		}
-		if ((args.length == 1) && args[0].equalsIgnoreCase("buildinfo")) {
-			sender.sendMessage(ChatColor.GOLD.toString() + plugin.getBuildInfo());
-			return true;
-		}
-		if ((args.length == 1) && args[0].equalsIgnoreCase("list")) {
-			for (ProtocolVersion version : ProtocolVersion.values()) {
-				if (version.isSupported()) {
-					sender.sendMessage(ChatColor.GOLD+"["+version.getName()+"]: "+ChatColor.GREEN+getPlayersStringForProtocol(version));
+		else if(args.length == 1) {
+			if (args[0].equalsIgnoreCase("buildinfo")) {
+				sender.sendMessage(ChatColor.GOLD.toString() + plugin.getBuildInfo());
+				return true;
+			}
+			else if (args[0].equalsIgnoreCase("list")) {
+				for (ProtocolVersion version : ProtocolVersion.values()) {
+					if (version.isSupported()) {
+						String res = getPlayersStringForProtocol(version);
+						if(res.length() > 0 || !plugin.getConfig().getBoolean("list-only-relevant-versions"))
+							sender.sendMessage(ChatColor.GOLD+"["+version.getName()+"]: "+ChatColor.GREEN+res);
+					}
 				}
+				return true;
 			}
-			return true;
-		}
-		if ((args.length == 1) && args[0].equalsIgnoreCase("debug")) {
-			if (ServerPlatform.get().getMiscUtils().isDebugging()) {
-				ServerPlatform.get().getMiscUtils().disableDebug();
-				sender.sendMessage(ChatColor.GOLD + "Disabled debug");
-			} else {
-				ServerPlatform.get().getMiscUtils().enableDebug();
-				sender.sendMessage(ChatColor.GOLD + "Enabled debug");
+			else if (args[0].equalsIgnoreCase("debug")) {
+				if (ServerPlatform.get().getMiscUtils().isDebugging()) {
+					ServerPlatform.get().getMiscUtils().disableDebug();
+					sender.sendMessage(ChatColor.GOLD + "Disabled debug");
+				} else {
+					ServerPlatform.get().getMiscUtils().enableDebug();
+					sender.sendMessage(ChatColor.GOLD + "Enabled debug");
+				}
+				return true;
 			}
-			return true;
-		}
-		if ((args.length == 1) && args[0].equalsIgnoreCase("leakdetector")) {
-			if (ResourceLeakDetector.isEnabled()) {
-				ResourceLeakDetector.setLevel(Level.DISABLED);
-				sender.sendMessage(ChatColor.GOLD + "Disabled leak detector");
-			} else {
-				ResourceLeakDetector.setLevel(Level.PARANOID);
-				sender.sendMessage(ChatColor.GOLD + "Enabled leak detector");
+			else if (args[0].equalsIgnoreCase("leakdetector")) {
+				if (ResourceLeakDetector.isEnabled()) {
+					ResourceLeakDetector.setLevel(Level.DISABLED);
+					sender.sendMessage(ChatColor.GOLD + "Disabled leak detector");
+				} else {
+					ResourceLeakDetector.setLevel(Level.PARANOID);
+					sender.sendMessage(ChatColor.GOLD + "Enabled leak detector");
+				}
+				return true;
 			}
-			return true;
-		}
-		if ((args.length == 1) && args[0].equalsIgnoreCase("connections")) {
-			for (Connection connection : ProtocolSupportAPI.getConnections()) {
-				sender.sendMessage(ChatColor.GREEN + connection.toString());
+			else if (args[0].equalsIgnoreCase("connections")) {
+				for (Connection connection : ProtocolSupportAPI.getConnections()) {
+					sender.sendMessage(ChatColor.GREEN + connection.toString());
+				}
+				return true;
 			}
-			return true;
 		}
-		return false;
+		sender.sendMessage("Usage: /protocolsupport [buildinfo|list|debug|leakdetector|connections]");
+		return true;
 	}
 
 	private String getPlayersStringForProtocol(ProtocolVersion version) {

--- a/src/protocolsupport/commands/CommandHandler.java
+++ b/src/protocolsupport/commands/CommandHandler.java
@@ -38,13 +38,14 @@ public class CommandHandler implements CommandExecutor, TabCompleter {
 				return true;
 			}
 			else if (args[0].equalsIgnoreCase("list")) {
+				sender.sendMessage(ChatColor.GREEN + "ProtocolSupport Players:");
 				for (ProtocolVersion version : ProtocolVersion.getAllSupported()) {
-					//if (version.isSupported()) {
 						String res = getPlayersStringForProtocol(version);
 						if(res.length() > 0 || (args.length == 2 && (args[1].equalsIgnoreCase("v") || args[1].equalsIgnoreCase("verbose"))))
 							sender.sendMessage(ChatColor.GOLD+"["+version.getName()+"]: "+ChatColor.GREEN+res);
-					//}
 				}
+				if(args.length == 1 || !(args[1].equalsIgnoreCase("v") || args[1].equalsIgnoreCase("verbose")))
+					sender.sendMessage(ChatColor.GOLD +"List all compatible versions using " + ChatColor.GREEN +"/ps list verbose");
 				return true;
 			}
 			else if (args[0].equalsIgnoreCase("debug")) {

--- a/src/protocolsupport/commands/CommandHandler.java
+++ b/src/protocolsupport/commands/CommandHandler.java
@@ -38,12 +38,12 @@ public class CommandHandler implements CommandExecutor, TabCompleter {
 				return true;
 			}
 			else if (args[0].equalsIgnoreCase("list")) {
-				for (ProtocolVersion version : ProtocolVersion.values()) {
-					if (version.isSupported()) {
+				for (ProtocolVersion version : ProtocolVersion.getAllSupported()) {
+					//if (version.isSupported()) {
 						String res = getPlayersStringForProtocol(version);
 						if(res.length() > 0 || (args.length == 2 && (args[1].equalsIgnoreCase("v") || args[1].equalsIgnoreCase("verbose"))))
 							sender.sendMessage(ChatColor.GOLD+"["+version.getName()+"]: "+ChatColor.GREEN+res);
-					}
+					//}
 				}
 				return true;
 			}
@@ -74,8 +74,7 @@ public class CommandHandler implements CommandExecutor, TabCompleter {
 				return true;
 			}
 		}
-		sender.sendMessage("Usage: /protocolsupport [buildinfo|list|debug|leakdetector|connections]");
-		return true;
+		return false;
 	}
 
 	private String getPlayersStringForProtocol(ProtocolVersion version) {


### PR DESCRIPTION
CommandHandler:
- Moved (args.length == 1) into one enclosing if statement
- Added proper usage message in case of invalid command. onCommand now
always returns true.
- Added checks for new config values (see below)

ProtocolSupport:
- Added two config values
- expose-plugin if set to false will send unknown command message if
someone without permission attempts to execute /ps to avoid exposure of
the plugin if wanted. default value is true (send "no power" message)
- list-only-relevant-versions if set to true will only list versions
that have connected players in /ps list ; default value is false (list
all versions regardless)

These changes should make ProtocolSupport commands more accessible to
users without programming knowledge.