### PR TITLE
[Patch] Fix for derpy snowman.

### DIFF
--- a/src/protocolsupport/protocol/typeremapper/watchedentity/remapper/SpecificRemapper.java
+++ b/src/protocolsupport/protocol/typeremapper/watchedentity/remapper/SpecificRemapper.java
@@ -289,8 +289,8 @@ public enum SpecificRemapper {
 		new Entry(new IndexValueRemapperNoOp<DataWatcherObjectVarInt>(DataWatcherObjectIndex.EnderDragon.PHASE, 11) {}, ProtocolVersionsHelper.ALL_1_9)
 	),
 	SNOWMAN(NetworkEntityType.SNOWMAN, SpecificRemapper.INSENTIENT,
-		new Entry(new IndexValueRemapperNoOp<DataWatcherObjectBoolean>(DataWatcherObjectIndex.Snowman.NO_HAT, 12) {}, ProtocolVersionsHelper.RANGE__1_10__1_12),
-		new Entry(new IndexValueRemapperNoOp<DataWatcherObjectBoolean>(DataWatcherObjectIndex.Snowman.NO_HAT, 11) {}, ProtocolVersionsHelper.ALL_1_9)
+		new Entry(new IndexValueRemapperNoOp<DataWatcherObjectByte>(DataWatcherObjectIndex.Snowman.NO_HAT, 12) {}, ProtocolVersionsHelper.RANGE__1_10__1_12),
+		new Entry(new IndexValueRemapperNoOp<DataWatcherObjectByte>(DataWatcherObjectIndex.Snowman.NO_HAT, 11) {}, ProtocolVersionsHelper.ALL_1_9)
 	),
 	ZOMBIE(NetworkEntityType.ZOMBIE, SpecificRemapper.INSENTIENT,
 		new Entry(new IndexValueRemapperNoOp<DataWatcherObjectBoolean>(DataWatcherObjectIndex.Zombie.BABY, 12) {}, ProtocolVersionsHelper.RANGE__1_10__1_12),


### PR DESCRIPTION
This simple patch fixes derpy snowmen. Tested in 1.12 and 1.9.
> Changed boolean to byte for noHat Snowmen. This is necessary because for some reason Mojang choose > this property to be send as the fifth bit in a byte.

At first I thought this was just an issue with Spigot. So I reported in on [there](https://hub.spigotmc.org/jira/browse/SPIGOT-3417).
 It turned out that they lacked an event caller, but the snowmen not showing was a result of ProtocolSupport. I am working on remapping all the values for PSPE, that's why I cought it. 
But really, we shouldn't forget the derpy snowmen! 😉 

![Derpy Snowman Image](https://hub.spigotmc.org/jira/secure/attachment/13120/VanillaWorks.png)