### PR TITLE
Implement "WorldCustomSound" packet

### DIFF
--- a/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_pe/WorldCustomSound.java
+++ b/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_pe/WorldCustomSound.java
@@ -1,0 +1,27 @@
+package protocolsupport.protocol.packet.middleimpl.clientbound.play.v_pe;
+
+import protocolsupport.api.ProtocolVersion;
+import protocolsupport.protocol.packet.middle.clientbound.play.MiddleWorldCustomSound;
+import protocolsupport.protocol.packet.middleimpl.ClientBoundPacketData;
+import protocolsupport.protocol.serializer.MiscSerializer;
+import protocolsupport.protocol.serializer.StringSerializer;
+import protocolsupport.protocol.serializer.VarNumberSerializer;
+import protocolsupport.protocol.typeremapper.pe.PEPacketIDs;
+import protocolsupport.utils.recyclable.RecyclableCollection;
+import protocolsupport.utils.recyclable.RecyclableSingletonList;
+
+public class WorldCustomSound extends MiddleWorldCustomSound {
+
+	@Override
+	public RecyclableCollection<ClientBoundPacketData> toData(ProtocolVersion version) {
+		ClientBoundPacketData serializer = ClientBoundPacketData.create(PEPacketIDs.PLAY_SOUND, version);
+		StringSerializer.writeString(serializer, version, id);
+		VarNumberSerializer.writeSVarInt(serializer, x);
+		VarNumberSerializer.writeVarInt(serializer, y);
+		VarNumberSerializer.writeSVarInt(serializer, z);
+		MiscSerializer.writeLFloat(serializer, volume);
+		MiscSerializer.writeLFloat(serializer, pitch);
+		return RecyclableSingletonList.create(serializer);
+	}
+
+}

--- a/src/protocolsupport/protocol/pipeline/version/v_pe/PEPacketEncoder.java
+++ b/src/protocolsupport/protocol/pipeline/version/v_pe/PEPacketEncoder.java
@@ -42,6 +42,7 @@ import protocolsupport.protocol.packet.middleimpl.clientbound.play.v_pe.SpawnPos
 import protocolsupport.protocol.packet.middleimpl.clientbound.play.v_pe.TimeUpdate;
 import protocolsupport.protocol.packet.middleimpl.clientbound.play.v_pe.Title;
 import protocolsupport.protocol.packet.middleimpl.clientbound.play.v_pe.UnloadChunk;
+import protocolsupport.protocol.packet.middleimpl.clientbound.play.v_pe.WorldCustomSound;
 import protocolsupport.protocol.packet.middleimpl.clientbound.play.v_pe.WorldEvent;
 import protocolsupport.protocol.pipeline.version.AbstractLegacyPacketEncoder;
 import protocolsupport.protocol.storage.NetworkDataCache;
@@ -92,6 +93,7 @@ public class PEPacketEncoder extends AbstractLegacyPacketEncoder {
 		registry.register(NetworkState.PLAY, ClientBoundPacket.PLAY_ENTITY_EFFECT_ADD_ID, EntityEffectAdd.class);
 		registry.register(NetworkState.PLAY, ClientBoundPacket.PLAY_ENTITY_EFFECT_REMOVE_ID, EntityEffectRemove.class);
 		registry.register(NetworkState.PLAY, ClientBoundPacket.PLAY_SET_PASSENGERS_ID, SetPassengers.class);
+		registry.register(NetworkState.PLAY, ClientBoundPacket.PLAY_WORLD_CUSTOM_SOUND_ID, WorldCustomSound.class);
 	}
 
 	public PEPacketEncoder(Connection connection, NetworkDataCache storage) {

--- a/src/protocolsupport/protocol/typeremapper/pe/PEPacketIDs.java
+++ b/src/protocolsupport/protocol/typeremapper/pe/PEPacketIDs.java
@@ -37,6 +37,7 @@ public class PEPacketIDs {
 	public static final int CHANGE_PLAYER_GAMETYPE = 62;
 	public static final int PLAYER_INFO = 63;
 	public static final int CHUNK_RADIUS = 70;
+	public static final int PLAY_SOUND = 87;
 	public static final int SET_TITLE = 89;
 
 }


### PR DESCRIPTION
Something that I did a long time ago but wasn't working due to the [missing resource pack handshake](https://github.com/ProtocolSupport/ProtocolSupport/pull/566).

Sounds still need to be remapped to their PE counterparts, but using `/playsound camera.take_picture master Steve 0 64 0` (or any other PE sound) plays the sound without any issues. 😉 