### PR TITLE
Convert legacy IDs spawn eggs from creative mode to modern NBT based spawn eggs

### DIFF
--- a/src/protocolsupport/protocol/typeremapper/itemstack/ItemStackRemapper.java
+++ b/src/protocolsupport/protocol/typeremapper/itemstack/ItemStackRemapper.java
@@ -13,6 +13,7 @@ import protocolsupport.api.ProtocolVersion;
 import protocolsupport.api.events.PlayerPropertiesResolveEvent.ProfileProperty;
 import protocolsupport.protocol.typeremapper.id.RemappingRegistry;
 import protocolsupport.protocol.typeremapper.id.RemappingTable.ComplexIdRemappingTable;
+import protocolsupport.protocol.typeremapper.itemstack.fromclient.MonsterEggFromLegacyIdRemapper;
 import protocolsupport.protocol.typeremapper.itemstack.fromclient.PotionFromLegacyIdRemapper;
 import protocolsupport.protocol.typeremapper.itemstack.toclient.BookPagesToLegacyTextSpecificRemapper;
 import protocolsupport.protocol.typeremapper.itemstack.toclient.DragonHeadSpecificRemapper;
@@ -252,6 +253,7 @@ public class ItemStackRemapper {
 		EnchantFilterNBTSpecificRemapper enchantfilter = new EnchantFilterNBTSpecificRemapper();
 		Arrays.stream(Material.values()).forEach(material -> registerToClientRemapper(material, enchantfilter, ProtocolVersionsHelper.ALL_PC));
 		registerFromClientRemapper(Material.POTION, new PotionFromLegacyIdRemapper(), ProtocolVersionsHelper.BEFORE_1_9);
+		registerFromClientRemapper(Material.MONSTER_EGG, new MonsterEggFromLegacyIdRemapper(), ProtocolVersionsHelper.BEFORE_1_9);
 	}
 
 	public static ItemStackWrapper remapToClient(ProtocolVersion version, String locale, int originalTypeId, ItemStackWrapper itemstack) {

--- a/src/protocolsupport/protocol/typeremapper/itemstack/fromclient/MonsterEggFromLegacyIdRemapper.java
+++ b/src/protocolsupport/protocol/typeremapper/itemstack/fromclient/MonsterEggFromLegacyIdRemapper.java
@@ -4,6 +4,7 @@ import org.bukkit.entity.EntityType;
 
 import protocolsupport.api.ProtocolVersion;
 import protocolsupport.protocol.typeremapper.itemstack.ItemStackSpecificRemapper;
+import protocolsupport.protocol.utils.minecraftdata.MinecraftData;
 import protocolsupport.zplatform.ServerPlatform;
 import protocolsupport.zplatform.itemstack.ItemStackWrapper;
 import protocolsupport.zplatform.itemstack.NBTTagCompoundWrapper;
@@ -15,14 +16,13 @@ public class MonsterEggFromLegacyIdRemapper implements ItemStackSpecificRemapper
 		EntityType type = EntityType.fromId(entityId); // ...so we get the EntityType from the ItemStack data value
 
 		if (type != null) { // Disallow invalid spawn eggs (prevent crashes)
-			// Get the ItemStack NBT tag (or create one if needed)
 			NBTTagCompoundWrapper tag = itemstack.getTag();
 			if (tag.isNull()) {
 				tag = ServerPlatform.get().getWrapperFactory().createEmptyNBTCompound();
 				itemstack.setTag(tag);
 			}
 			NBTTagCompoundWrapper nbtEntity = ServerPlatform.get().getWrapperFactory().createEmptyNBTCompound();
-			nbtEntity.setString("id", "minecraft:" + type.getName());
+			nbtEntity.setString("id", MinecraftData.addNamespacePrefix(type.getName()));
 			tag.setCompound("EntityTag", nbtEntity);
 			itemstack.setData(0); // Reset the egg data value to 0
 		}

--- a/src/protocolsupport/protocol/typeremapper/itemstack/fromclient/MonsterEggFromLegacyIdRemapper.java
+++ b/src/protocolsupport/protocol/typeremapper/itemstack/fromclient/MonsterEggFromLegacyIdRemapper.java
@@ -1,0 +1,31 @@
+package protocolsupport.protocol.typeremapper.itemstack.fromclient;
+
+import org.bukkit.entity.EntityType;
+
+import protocolsupport.api.ProtocolVersion;
+import protocolsupport.protocol.typeremapper.itemstack.ItemStackSpecificRemapper;
+import protocolsupport.zplatform.ServerPlatform;
+import protocolsupport.zplatform.itemstack.ItemStackWrapper;
+import protocolsupport.zplatform.itemstack.NBTTagCompoundWrapper;
+
+public class MonsterEggFromLegacyIdRemapper implements ItemStackSpecificRemapper {
+	@Override
+	public ItemStackWrapper remap(ProtocolVersion version, String locale, ItemStackWrapper itemstack) {
+		int entityId = itemstack.getData(); // In pre-1.9 versions, the data value from the spawn egg is actually the entity ID
+		EntityType type = EntityType.fromId(entityId); // ...so we get the EntityType from the ItemStack data value
+
+		if (type != null) { // Disallow invalid spawn eggs (prevent crashes)
+			// Get the ItemStack NBT tag (or create one if needed)
+			NBTTagCompoundWrapper tag = itemstack.getTag();
+			if (tag.isNull()) {
+				tag = ServerPlatform.get().getWrapperFactory().createEmptyNBTCompound();
+				itemstack.setTag(tag);
+			}
+			NBTTagCompoundWrapper nbtEntity = ServerPlatform.get().getWrapperFactory().createEmptyNBTCompound();
+			nbtEntity.setString("id", "minecraft:" + type.getName());
+			tag.setCompound("EntityTag", nbtEntity);
+			itemstack.setData(0); // Reset the egg data value to 0
+		}
+		return itemstack;
+	}
+}


### PR DESCRIPTION
Converts legacy (data value based) spawn eggs to modern (NBT based) spawn eggs.

Fixes issues when getting spawn eggs from creative in pre-1.9 clients.

![http://i.imgur.com/GZE9eR6.png](http://i.imgur.com/GZE9eR6.png)

The data value is also stripped out when converting to modern spawn eggs.

![http://i.imgur.com/NRoUVgp.png](http://i.imgur.com/NRoUVgp.png)

(Spawn egg from 1.8, given to a 1.12 client)