### PR TITLE
Skip unknown string on Chat

### DIFF
--- a/src/protocolsupport/protocol/packet/middleimpl/serverbound/play/v_pe/Chat.java
+++ b/src/protocolsupport/protocol/packet/middleimpl/serverbound/play/v_pe/Chat.java
@@ -25,6 +25,7 @@ public class Chat extends MiddleChat {
 		ProtocolVersion version = connection.getVersion();
 		int type = clientdata.readUnsignedByte();
 		Validate.isTrue(type == validChatType, MessageFormat.format("Unxepected serverbound chat type, expected {0}, but received {1}", validChatType, type));
+		StringSerializer.readString(clientdata, version); //skip unknown string (seems to be empty)
 		StringSerializer.readString(clientdata, version); //skip sender
 		message = StringSerializer.readString(clientdata, version);
 		if ((message.length() >= 2) && cmdCharacters.contains(message.charAt(0)) && (message.charAt(1) == '/')) {


### PR DESCRIPTION
**This field should be checked in IDA to see what is its real purpose.**

It seems 1.2 added a new (unknown) field in the Chat packet.

After debugging a little bit, this string is always empty no matter what I did.

```
[18:45:42 INFO]: ???:
[18:45:42 INFO]: sender: MrPowerGamerBR
[18:45:42 INFO]: message: test test test
[18:45:42 INFO]: <MrPowerGamerBR> test test test
```