### PR TITLE
Add command support using slashes, remove old command prefixes

### DIFF
--- a/src/protocolsupport/protocol/packet/middle/serverbound/play/MiddleChat.java
+++ b/src/protocolsupport/protocol/packet/middle/serverbound/play/MiddleChat.java
@@ -1,5 +1,7 @@
 package protocolsupport.protocol.packet.middle.serverbound.play;
 
+import protocolsupport.api.ProtocolType;
+import protocolsupport.api.ProtocolVersion;
 import protocolsupport.protocol.packet.ServerBoundPacket;
 import protocolsupport.protocol.packet.middle.ServerBoundMiddlePacket;
 import protocolsupport.protocol.packet.middleimpl.ServerBoundPacketData;
@@ -19,4 +21,9 @@ public abstract class MiddleChat extends ServerBoundMiddlePacket {
 		return RecyclableSingletonList.create(creator);
 	}
 
+	public static ServerBoundPacketData create(String message) {
+		ServerBoundPacketData creator = ServerBoundPacketData.create(ServerBoundPacket.PLAY_CHAT);
+		StringSerializer.writeString(creator, ProtocolVersion.getLatest(ProtocolType.PC), message);
+		return creator;
+	}
 }

--- a/src/protocolsupport/protocol/packet/middle/serverbound/play/MiddleChat.java
+++ b/src/protocolsupport/protocol/packet/middle/serverbound/play/MiddleChat.java
@@ -1,7 +1,5 @@
 package protocolsupport.protocol.packet.middle.serverbound.play;
 
-import protocolsupport.api.ProtocolType;
-import protocolsupport.api.ProtocolVersion;
 import protocolsupport.protocol.packet.ServerBoundPacket;
 import protocolsupport.protocol.packet.middle.ServerBoundMiddlePacket;
 import protocolsupport.protocol.packet.middleimpl.ServerBoundPacketData;
@@ -16,14 +14,12 @@ public abstract class MiddleChat extends ServerBoundMiddlePacket {
 
 	@Override
 	public RecyclableCollection<ServerBoundPacketData> toNative() {
-		ServerBoundPacketData creator = ServerBoundPacketData.create(ServerBoundPacket.PLAY_CHAT);
-		StringSerializer.writeString(creator, ProtocolVersionsHelper.LATEST_PC, message);
-		return RecyclableSingletonList.create(creator);
+		return RecyclableSingletonList.create(create(message));
 	}
 
 	public static ServerBoundPacketData create(String message) {
 		ServerBoundPacketData creator = ServerBoundPacketData.create(ServerBoundPacket.PLAY_CHAT);
-		StringSerializer.writeString(creator, ProtocolVersion.getLatest(ProtocolType.PC), message);
+		StringSerializer.writeString(creator, ProtocolVersionsHelper.LATEST_PC, message);
 		return creator;
 	}
 }

--- a/src/protocolsupport/protocol/packet/middleimpl/serverbound/play/v_pe/Chat.java
+++ b/src/protocolsupport/protocol/packet/middleimpl/serverbound/play/v_pe/Chat.java
@@ -1,7 +1,6 @@
 package protocolsupport.protocol.packet.middleimpl.serverbound.play.v_pe;
 
 import java.text.MessageFormat;
-import java.util.HashSet;
 
 import org.apache.commons.lang3.Validate;
 
@@ -14,12 +13,6 @@ public class Chat extends MiddleChat {
 
 	private static final int validChatType = 1;
 
-	public static final HashSet<Character> cmdCharacters = new HashSet<>();
-	static {
-		cmdCharacters.add('!');
-		cmdCharacters.add('.');
-	}
-
 	@Override
 	public void readFromClientData(ByteBuf clientdata) {
 		ProtocolVersion version = connection.getVersion();
@@ -27,9 +20,6 @@ public class Chat extends MiddleChat {
 		Validate.isTrue(type == validChatType, MessageFormat.format("Unxepected serverbound chat type, expected {0}, but received {1}", validChatType, type));
 		StringSerializer.readString(clientdata, version); //skip sender
 		message = StringSerializer.readString(clientdata, version);
-		if ((message.length() >= 2) && cmdCharacters.contains(message.charAt(0)) && (message.charAt(1) == '/')) {
-			message = message.substring(1);
-		}
 	}
 
 }

--- a/src/protocolsupport/protocol/packet/middleimpl/serverbound/play/v_pe/CommandRequest.java
+++ b/src/protocolsupport/protocol/packet/middleimpl/serverbound/play/v_pe/CommandRequest.java
@@ -12,16 +12,13 @@ import protocolsupport.utils.recyclable.RecyclableSingletonList;
 public class CommandRequest extends ServerBoundMiddlePacket {
 
 	protected String command;
-	protected int type;
-	protected String requestId;
-	protected int playerId;
 
 	@Override
 	public void readFromClientData(ByteBuf clientdata) {
 		command = StringSerializer.readString(clientdata, connection.getVersion());
-		type = VarNumberSerializer.readVarInt(clientdata);
-		requestId = StringSerializer.readString(clientdata, connection.getVersion());
-		playerId = VarNumberSerializer.readSVarInt(clientdata);
+		VarNumberSerializer.readVarInt(clientdata); // type
+		StringSerializer.readString(clientdata, connection.getVersion()); // request ID
+		VarNumberSerializer.readSVarInt(clientdata); // player ID
 	}
 
 	@Override

--- a/src/protocolsupport/protocol/packet/middleimpl/serverbound/play/v_pe/CommandRequest.java
+++ b/src/protocolsupport/protocol/packet/middleimpl/serverbound/play/v_pe/CommandRequest.java
@@ -1,0 +1,31 @@
+package protocolsupport.protocol.packet.middleimpl.serverbound.play.v_pe;
+
+import io.netty.buffer.ByteBuf;
+import protocolsupport.protocol.packet.middle.ServerBoundMiddlePacket;
+import protocolsupport.protocol.packet.middle.serverbound.play.MiddleChat;
+import protocolsupport.protocol.packet.middleimpl.ServerBoundPacketData;
+import protocolsupport.protocol.serializer.StringSerializer;
+import protocolsupport.protocol.serializer.VarNumberSerializer;
+import protocolsupport.utils.recyclable.RecyclableCollection;
+import protocolsupport.utils.recyclable.RecyclableSingletonList;
+
+public class CommandRequest extends ServerBoundMiddlePacket {
+
+	protected String command;
+	protected int type;
+	protected String requestId;
+	protected int playerId;
+
+	@Override
+	public void readFromClientData(ByteBuf clientdata) {
+		command = StringSerializer.readString(clientdata, connection.getVersion());
+		type = VarNumberSerializer.readVarInt(clientdata);
+		requestId = StringSerializer.readString(clientdata, connection.getVersion());
+		playerId = VarNumberSerializer.readSVarInt(clientdata);
+	}
+
+	@Override
+	public RecyclableCollection<ServerBoundPacketData> toNative() {
+		return RecyclableSingletonList.create(MiddleChat.create(command));
+	}
+}

--- a/src/protocolsupport/protocol/pipeline/version/v_pe/PEPacketDecoder.java
+++ b/src/protocolsupport/protocol/pipeline/version/v_pe/PEPacketDecoder.java
@@ -14,6 +14,7 @@ import protocolsupport.protocol.packet.middleimpl.serverbound.play.v_pe.Chat;
 import protocolsupport.protocol.packet.middleimpl.serverbound.play.v_pe.Interact;
 import protocolsupport.protocol.packet.middleimpl.serverbound.play.v_pe.PlayerAction;
 import protocolsupport.protocol.packet.middleimpl.serverbound.play.v_pe.PositionLook;
+import protocolsupport.protocol.packet.middleimpl.serverbound.play.v_pe.CommandRequest;
 import protocolsupport.protocol.pipeline.version.AbstractPacketDecoder;
 import protocolsupport.protocol.serializer.VarNumberSerializer;
 import protocolsupport.protocol.storage.NetworkDataCache;
@@ -35,6 +36,7 @@ public class PEPacketDecoder extends AbstractPacketDecoder {
 		registry.register(NetworkState.PLAY, PEPacketIDs.CHAT, Chat.class);
 		registry.register(NetworkState.PLAY, PEPacketIDs.ANIMATION, Animation.class);
 		registry.register(NetworkState.PLAY, PEPacketIDs.INTERACT, Interact.class);
+		registry.register(NetworkState.PLAY, PEPacketIDs.COMMAND_REQUEST, CommandRequest.class);
 	}
 
 	public PEPacketDecoder(Connection connection, NetworkDataCache cache) {

--- a/src/protocolsupport/protocol/typeremapper/pe/PEPacketIDs.java
+++ b/src/protocolsupport/protocol/typeremapper/pe/PEPacketIDs.java
@@ -62,7 +62,7 @@ public class PEPacketIDs {
 	//public static final int BOSS_EVENT = 74;
 	//public static final int SHOW_CREDITS = 75;
 	//public static final int TAB_COMPLETE = 76;
-	//public static final int COMMAND_REQUEST = 77;
+	public static final int COMMAND_REQUEST = 77;
 	//public static final int COMMAND_BLOCK_UPDATE = 78;
 	//public static final int TRADE_UPDATE = 80;
 	//public static final int EQUIPMENT = 81;


### PR DESCRIPTION
This implements the "Request Command" packet, which, since 1.2, allows commands not sent via the available command packet to be executed.

While this code works:tm:, the code within `MiddleChat#create(...)` is so protocol dependent that it almost hurts inside when reading it, I tried finding any other examples of other MiddleXYZ packets that has that method implement but almost none of them has it. (and the ones that has it doesn't need the version object) so I wonder if that's the proper way to do it. 👍

Anyway, this reads the request command packet and creates a MiddleChat packet for the server to process.

This commit also removes the old command prefixes `mcpenew` branch had to execute commands, since this commit obsoletes that old "hack".

![https://cdn.discordapp.com/attachments/286106780189065216/342793496031133696/Screenshot_20170803-191813.png](https://cdn.discordapp.com/attachments/286106780189065216/342793496031133696/Screenshot_20170803-191813.png)