### PR TITLE
Avoid gc stressing MessageFormat.format call

### DIFF
--- a/src/protocolsupport/api/ProtocolVersion.java
+++ b/src/protocolsupport/api/ProtocolVersion.java
@@ -361,7 +361,7 @@ public enum ProtocolVersion {
 		public int compareTo(OrderId o) {
 			Validate.isTrue(this.type != ProtocolType.UNKNOWN, "Can't compare unknown protocol type");
 			Validate.isTrue(o.type != ProtocolType.UNKNOWN, "Can't compare with unknown protocol type");
-			Validate.isTrue(this.type == o.type, MessageFormat.format("Cant compare order from different types: this - {0}, other - {1}", type, o.type));
+			Validate.isTrue(this.type == o.type, "Cant compare order from different types");
 			return Integer.compare(id, o.id);
 		}
 


### PR DESCRIPTION
Avoid MessageFormat.format call in protocolsupport.api.ProtocolVersion.OrderId.compareTo because it produces huge amounts of characters (600kB/player/second on our spigot servers). Maybe a simple "Cant compare order from different types" or "Cant compare order from different types: this - " + type + ", other - " + o.type will be sufficient to avoid the format call.

![image](https://user-images.githubusercontent.com/1752009/29070291-0122bc3a-7c3f-11e7-9de0-de39bdecd6b7.png)

Image shows 5 Minutes of jmc Flight Recording on ~10 Player Spigot server. 