### PR TITLE
Update remappers for MCPE 1.2

### DIFF
--- a/src/protocolsupport/protocol/typeremapper/itemstack/ItemStackRemapper.java
+++ b/src/protocolsupport/protocol/typeremapper/itemstack/ItemStackRemapper.java
@@ -16,6 +16,7 @@ import protocolsupport.protocol.typeremapper.itemstack.toclient.BookPagesToLegac
 import protocolsupport.protocol.typeremapper.itemstack.toclient.DragonHeadSpecificRemapper;
 import protocolsupport.protocol.typeremapper.itemstack.toclient.EmptyBookPageAdderSpecificRemapper;
 import protocolsupport.protocol.typeremapper.itemstack.toclient.EnchantFilterNBTSpecificRemapper;
+import protocolsupport.protocol.typeremapper.itemstack.toclient.ItemIdToPEIdSpecificRemapper;
 import protocolsupport.protocol.typeremapper.itemstack.toclient.MonsterEggToLegacyIdSpecificRemapper;
 import protocolsupport.protocol.typeremapper.itemstack.toclient.MonsterEggToLegacyNameSpecificRemapper;
 import protocolsupport.protocol.typeremapper.itemstack.toclient.PlayerSkullToLegacyOwnerSpecificRemapper;
@@ -247,6 +248,8 @@ public class ItemStackRemapper {
 		registerToClientRemapper(Material.BOOK_AND_QUILL, new EmptyBookPageAdderSpecificRemapper(), ProtocolVersionsHelper.ALL_PC);
 		EnchantFilterNBTSpecificRemapper enchantfilter = new EnchantFilterNBTSpecificRemapper();
 		Arrays.stream(Material.values()).forEach(material -> registerToClientRemapper(material, enchantfilter, ProtocolVersionsHelper.ALL_PC));
+		ItemIdToPEIdSpecificRemapper itemtope = new ItemIdToPEIdSpecificRemapper();
+		Arrays.stream(Material.values()).forEach(material -> registerToClientRemapper(material, itemtope, ProtocolVersion.MINECRAFT_PE));
 		registerFromClientRemapper(Material.POTION, new PotionFromLegacyIdRemapper(), ProtocolVersionsHelper.BEFORE_1_9);
 		registerFromClientRemapper(Material.MONSTER_EGG, new MonsterEggFromLegacyIdRemapper(), ProtocolVersionsHelper.BEFORE_1_9);
 	}

--- a/src/protocolsupport/protocol/typeremapper/itemstack/toclient/ItemIdToPEIdSpecificRemapper.java
+++ b/src/protocolsupport/protocol/typeremapper/itemstack/toclient/ItemIdToPEIdSpecificRemapper.java
@@ -1,0 +1,22 @@
+package protocolsupport.protocol.typeremapper.itemstack.toclient;
+
+import protocolsupport.api.ProtocolVersion;
+import protocolsupport.api.TranslationAPI;
+import protocolsupport.protocol.typeremapper.itemstack.ItemStackSpecificRemapper;
+import protocolsupport.protocol.typeremapper.legacy.LegacyPotion;
+import protocolsupport.protocol.typeremapper.pe.PEDataValues;
+import protocolsupport.protocol.utils.minecraftdata.PotionData;
+import protocolsupport.zplatform.itemstack.ItemStackWrapper;
+import protocolsupport.zplatform.itemstack.NBTTagCompoundWrapper;
+import protocolsupport.zplatform.itemstack.NBTTagListWrapper;
+import protocolsupport.zplatform.itemstack.NBTTagType;
+
+public class ItemIdToPEIdSpecificRemapper implements ItemStackSpecificRemapper {
+
+	@Override
+	public ItemStackWrapper remap(ProtocolVersion version, String locale, ItemStackWrapper itemstack) {
+		itemstack.setTypeId(PEDataValues.ITEM_ID.getRemap(itemstack.getTypeId()));
+		return itemstack;
+	}
+
+}

--- a/src/protocolsupport/protocol/typeremapper/pe/PEDataValues.java
+++ b/src/protocolsupport/protocol/typeremapper/pe/PEDataValues.java
@@ -113,11 +113,9 @@ public class PEDataValues {
 		}
 	}
 
-	public static final ArrayBasedIdRemappingTable ITEM_ID = new ArrayBasedIdRemappingTable(MinecraftData.ITEM_ID_MAX * MinecraftData.ITEM_DATA_MAX);
+	public static final ArrayBasedIdRemappingTable ITEM_ID = new ArrayBasedIdRemappingTable(MinecraftData.ITEM_ID_MAX);
 	private static void registerItemRemap(int from, int to) {
-		for (int i = 0; i < MinecraftData.ITEM_DATA_MAX; i++) {
-			ITEM_ID.setRemap(MinecraftData.getBlockStateFromIdAndData(from, i), MinecraftData.getBlockStateFromIdAndData(to, i));
-		}
+		ITEM_ID.setRemap(from, to);
 	}
 
 	static {

--- a/src/protocolsupport/protocol/typeremapper/pe/PEDataValues.java
+++ b/src/protocolsupport/protocol/typeremapper/pe/PEDataValues.java
@@ -113,6 +113,23 @@ public class PEDataValues {
 		}
 	}
 
+	public static final ArrayBasedIdRemappingTable ITEM_ID = new ArrayBasedIdRemappingTable(MinecraftData.ITEM_ID_MAX * MinecraftData.ITEM_DATA_MAX);
+	private static void registerItemRemap(int from, int to) {
+		for (int i = 0; i < MinecraftData.ITEM_DATA_MAX; i++) {
+			ITEM_ID.setRemap(MinecraftData.getBlockStateFromIdAndData(from, i), MinecraftData.getBlockStateFromIdAndData(to, i));
+		}
+	}
+	private static void registerItemRemap(int from, int dataFrom, int to, int dataTo) {
+		for (int i = 0; i < MinecraftData.ITEM_DATA_MAX; i++) {
+			ITEM_ID.setRemap(MinecraftData.getBlockStateFromIdAndData(from, dataFrom), MinecraftData.getBlockStateFromIdAndData(to, dataTo));
+		}
+	}
+	private static void registerItemRemap(int from, int to, int dataTo) {
+		for (int i = 0; i < MinecraftData.ITEM_DATA_MAX; i++) {
+			ITEM_ID.setRemap(MinecraftData.getBlockStateFromIdAndData(from, i), MinecraftData.getBlockStateFromIdAndData(to, dataTo));
+		}
+	}
+
 	static {
 		// Nether slab -> Quartz slab
 		registerBlockRemap(44, 7, 44, 6);
@@ -193,10 +210,26 @@ public class PEDataValues {
 		registerBlockRemap(158, 125);
 		// Beetroot
 		registerBlockRemap(207, 244);
+		// Structure Block
+		registerBlockRemap(255, 252);
 
-		// ===[ MISSING BLOCK REMAPS ]===
-		// Jukebox -> Noteblock
-		registerBlockRemap(84, 25);
+		// Armor Stand
+		registerItemRemap(416, 425);
+		// Banner
+		registerItemRemap(425, 446);
+		// Records
+		registerItemRemap(2256, 500);
+		registerItemRemap(2257, 501);
+		registerItemRemap(2258, 502);
+		registerItemRemap(2259, 503);
+		registerItemRemap(2260, 504);
+		registerItemRemap(2261, 505);
+		registerItemRemap(2262, 506);
+		registerItemRemap(2263, 507);
+		registerItemRemap(2264, 508);
+		registerItemRemap(2265, 509);
+		registerItemRemap(2266, 510);
+		registerItemRemap(2267, 511);
 	}
 
 }

--- a/src/protocolsupport/protocol/typeremapper/pe/PEDataValues.java
+++ b/src/protocolsupport/protocol/typeremapper/pe/PEDataValues.java
@@ -119,16 +119,6 @@ public class PEDataValues {
 			ITEM_ID.setRemap(MinecraftData.getBlockStateFromIdAndData(from, i), MinecraftData.getBlockStateFromIdAndData(to, i));
 		}
 	}
-	private static void registerItemRemap(int from, int dataFrom, int to, int dataTo) {
-		for (int i = 0; i < MinecraftData.ITEM_DATA_MAX; i++) {
-			ITEM_ID.setRemap(MinecraftData.getBlockStateFromIdAndData(from, dataFrom), MinecraftData.getBlockStateFromIdAndData(to, dataTo));
-		}
-	}
-	private static void registerItemRemap(int from, int to, int dataTo) {
-		for (int i = 0; i < MinecraftData.ITEM_DATA_MAX; i++) {
-			ITEM_ID.setRemap(MinecraftData.getBlockStateFromIdAndData(from, i), MinecraftData.getBlockStateFromIdAndData(to, dataTo));
-		}
-	}
 
 	static {
 		// Nether slab -> Quartz slab


### PR DESCRIPTION
Updates the block remapper for MCPE 1.2

This PR also adds a item remapper, because Mojang loves changing the item IDs to differ from PC -> PE.