### PR TITLE
[PSPE] start the raknet server on the same ip as the mc server

### DIFF
--- a/src/protocolsupport/zplatform/impl/glowstone/injector/GlowStoneNettyInjector.java
+++ b/src/protocolsupport/zplatform/impl/glowstone/injector/GlowStoneNettyInjector.java
@@ -74,7 +74,11 @@ public class GlowStoneNettyInjector {
 	public static void startPEServer() {
 		try {
 			GameServer gameserver = getGameServer();
-			peserver = new RakNetServer(new InetSocketAddress(PENetServerConstants.TEST_PORT), PENetServerConstants.PING_HANDLER, new UserChannelInitializer() {
+			String serverIp = gameserver.getServer().getIp();
+			if (serverIp.isEmpty()) {
+				serverIp = "0.0.0.0";
+			}
+			peserver = new RakNetServer(new InetSocketAddress(serverIp,PENetServerConstants.TEST_PORT), PENetServerConstants.PING_HANDLER, new UserChannelInitializer() {
 				@Override
 				public void init(Channel channel) {
 					MessageHandler networkmanager = new MessageHandler(gameserver);

--- a/src/protocolsupport/zplatform/impl/spigot/injector/network/SpigotNettyInjector.java
+++ b/src/protocolsupport/zplatform/impl/spigot/injector/network/SpigotNettyInjector.java
@@ -63,7 +63,11 @@ public class SpigotNettyInjector {
 	public static void startPEServer() {
 		try {
 			List<NetworkManager> networkmanagerlist = getNetworkManagerList();
-			peserver = new RakNetServer(new InetSocketAddress(PENetServerConstants.TEST_PORT), PENetServerConstants.PING_HANDLER, new UserChannelInitializer() {
+			String serverIp = SpigotMiscUtils.getServer().server.getIp();
+			if (serverIp.isEmpty()) {
+				serverIp = "0.0.0.0";
+			}
+			peserver = new RakNetServer(new InetSocketAddress(serverIp,PENetServerConstants.TEST_PORT), PENetServerConstants.PING_HANDLER, new UserChannelInitializer() {
 				@Override
 				public void init(Channel channel) {
 					NetworkManager networkmanager = new NetworkManager(EnumProtocolDirection.SERVERBOUND);


### PR DESCRIPTION
this change makes the raknet server start on the same ip/interface as the one defined in the config file of the server.