### PR TITLE
Fix "Can't compare order from different types", fix subtitle updating for MCPE clients

### DIFF
--- a/src/protocolsupport/protocol/packet/middle/clientbound/play/MiddleChat.java
+++ b/src/protocolsupport/protocol/packet/middle/clientbound/play/MiddleChat.java
@@ -1,6 +1,7 @@
 package protocolsupport.protocol.packet.middle.clientbound.play;
 
 import io.netty.buffer.ByteBuf;
+import protocolsupport.api.ProtocolType;
 import protocolsupport.api.ProtocolVersion;
 import protocolsupport.api.chat.ChatAPI;
 import protocolsupport.api.chat.ChatAPI.MessagePosition;
@@ -22,6 +23,7 @@ public abstract class MiddleChat extends ClientBoundMiddlePacket {
 
 	@Override
 	public boolean postFromServerRead() {
+		if (connection.getVersion().getProtocolType() != ProtocolType.PC) { return true; }
 		return connection.getVersion().isAfterOrEq(ProtocolVersion.MINECRAFT_1_8) || (position != MessagePosition.HOTBAR);
 	}
 

--- a/src/protocolsupport/protocol/packet/middle/clientbound/play/MiddleCollectEffect.java
+++ b/src/protocolsupport/protocol/packet/middle/clientbound/play/MiddleCollectEffect.java
@@ -6,6 +6,7 @@ import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 
 import io.netty.buffer.ByteBuf;
+import protocolsupport.api.ProtocolType;
 import protocolsupport.api.ProtocolVersion;
 import protocolsupport.protocol.packet.middle.ClientBoundMiddlePacket;
 import protocolsupport.protocol.serializer.VarNumberSerializer;
@@ -26,6 +27,7 @@ public abstract class MiddleCollectEffect extends ClientBoundMiddlePacket {
 
 	@Override
 	public boolean postFromServerRead() {
+		if (connection.getVersion().getProtocolType() != ProtocolType.PC) { return true; }
 		if (connection.getVersion().isBefore(ProtocolVersion.MINECRAFT_1_9)) {
 			Player player = connection.getPlayer();
 			NetworkEntity entity = cache.getWatchedEntity(entityId);

--- a/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_pe/Title.java
+++ b/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_pe/Title.java
@@ -7,6 +7,7 @@ import protocolsupport.protocol.packet.middleimpl.ClientBoundPacketData;
 import protocolsupport.protocol.serializer.StringSerializer;
 import protocolsupport.protocol.serializer.VarNumberSerializer;
 import protocolsupport.protocol.typeremapper.pe.PEPacketIDs;
+import protocolsupport.utils.recyclable.RecyclableArrayList;
 import protocolsupport.utils.recyclable.RecyclableCollection;
 import protocolsupport.utils.recyclable.RecyclableSingletonList;
 
@@ -30,15 +31,24 @@ public class Title extends MiddleTitle {
 				return RecyclableSingletonList.create(create(version, RESET, "", 0, 0, 0));
 			}
 			case SET_TITLE: {
+				String title = message.toLegacyText(cache.getLocale());
+				cache.setTitle(title);
+				cache.setLastSentTitle(System.currentTimeMillis());
 				return RecyclableSingletonList.create(create(version, SET_TITLE, message.toLegacyText(cache.getLocale()), 0, 0, 0));
 			}
 			case SET_SUBTITLE: {
-				return RecyclableSingletonList.create(create(version, SET_SUBTITLE, message.toLegacyText(cache.getLocale()), 0, 0, 0));
+				RecyclableArrayList<ClientBoundPacketData> packets = RecyclableArrayList.create();
+				packets.add(create(version, SET_SUBTITLE, message.toLegacyText(cache.getLocale()), 0, 0, 0));
+				if (cache.getLastSentTitle() + (cache.getVisibleOnScreenTicks() * 50) > System.currentTimeMillis()) {
+					packets.add(create(version, SET_TITLE, cache.getTitle(), 0, 0, 0));
+				}
+				return packets;
 			}
 			case SET_ACTION_BAR: {
 				return RecyclableSingletonList.create(create(version, SET_ACTION_BAR, message.toLegacyText(cache.getLocale()), 0, 0, 0));
 			}
 			case SET_TIMES: {
+				cache.setVisibleOnScreenTicks(fadeIn + stay + fadeOut);
 				return RecyclableSingletonList.create(create(version, SET_TIMINGS, "", fadeIn, stay, fadeOut));
 			}
 			default: {

--- a/src/protocolsupport/protocol/storage/NetworkDataCache.java
+++ b/src/protocolsupport/protocol/storage/NetworkDataCache.java
@@ -333,4 +333,19 @@ public class NetworkDataCache {
 
 	public NBTTagCompoundWrapper getSignTag() { return signTag; }
 
+	private String title;
+	private int visibleOnScreenTicks = 100; // default fadeIn = 20; default stay = 60; default fadeOut = 20;
+	private long lastSentTitle;
+
+	public String getTitle() { return title; }
+
+	public void setTitle(String title) { this.title = title; }
+
+	public int getVisibleOnScreenTicks() { return visibleOnScreenTicks; }
+
+	public void setVisibleOnScreenTicks(int visibleOnScreenTicks) { this.visibleOnScreenTicks = visibleOnScreenTicks; }
+
+	public long getLastSentTitle() { return lastSentTitle; }
+
+	public void setLastSentTitle(long lastSentTitle) { this.lastSentTitle = lastSentTitle; }
 }


### PR DESCRIPTION
The important stuff here is the subtitle updating packet.

Before this commit, if a plugin (or if you used `/title`) did this

`player.sendTitle("hello", "world", 20, 60, 20);`

The client would only show "hello"

If, after sending that, you did this

`player.sendTitle("ProtocolSupportPE", "is awesome!", 20, 60, 20);`

the client would show "ProtocolSupportPE" and "world"

This commit fixes that by sending a title packet after the subtitle packet, however I also needed to do some calculations to figure out if the title is still visible on the PE client, to avoid visible titles when using commands that should not display a new title, like `/title player subtitle`

The only minor inconvenience with this commit is that, if you update the subtitle while the title is already visible on screen, the title will start the fading process again. (in PC the subtitle would be displayed right away, before this commit updating the subtitle while the title is visible would have no effect in PE clients)