### PR TITLE
Fix clients below 1.9 hearing pickup sounds globally

### DIFF
--- a/src/protocolsupport/protocol/packet/middle/clientbound/play/MiddleCollectEffect.java
+++ b/src/protocolsupport/protocol/packet/middle/clientbound/play/MiddleCollectEffect.java
@@ -1,15 +1,15 @@
 package protocolsupport.protocol.packet.middle.clientbound.play;
 
-import java.util.concurrent.ThreadLocalRandom;
-
-import org.bukkit.Sound;
-import org.bukkit.entity.Player;
-
 import io.netty.buffer.ByteBuf;
+import org.bukkit.Sound;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
 import protocolsupport.api.ProtocolVersion;
 import protocolsupport.protocol.packet.middle.ClientBoundMiddlePacket;
 import protocolsupport.protocol.serializer.VarNumberSerializer;
 import protocolsupport.protocol.utils.types.NetworkEntity;
+
+import java.util.concurrent.ThreadLocalRandom;
 
 public abstract class MiddleCollectEffect extends ClientBoundMiddlePacket {
 
@@ -29,18 +29,19 @@ public abstract class MiddleCollectEffect extends ClientBoundMiddlePacket {
 		if (connection.getVersion().isBefore(ProtocolVersion.MINECRAFT_1_9)) {
 			Player player = connection.getPlayer();
 			NetworkEntity entity = cache.getWatchedEntity(entityId);
-			if ((entity != null) && (player != null)) {
+			if ((entity != null && entity.getUUID() != null) && (player != null)) {
+				Entity worldEntity = player.getServer().getEntity(entity.getUUID());
 				switch (entity.getType()) {
 					case ITEM: {
 						player.playSound(
-							player.getLocation(), Sound.ENTITY_ITEM_PICKUP,
+							worldEntity.getLocation(), Sound.ENTITY_ITEM_PICKUP,
 							0.2F, (((ThreadLocalRandom.current().nextFloat() - ThreadLocalRandom.current().nextFloat()) * 0.7F) + 1.0F) * 2.0F
 						);
 						break;
 					}
 					case EXP_ORB: {
 						player.playSound(
-							player.getLocation(), Sound.ENTITY_EXPERIENCE_ORB_PICKUP,
+							worldEntity.getLocation(), Sound.ENTITY_EXPERIENCE_ORB_PICKUP,
 							0.2F, (((ThreadLocalRandom.current().nextFloat() - ThreadLocalRandom.current().nextFloat()) * 0.7F) + 1.0F) * 2.0F
 						);
 						break;


### PR DESCRIPTION
Since commit https://github.com/ProtocolSupport/ProtocolSupport/commit/c9c462a393b60981fcbd6d69418d8c284cef6b5b players using a client version below 1.9 have heard item pickup sounds for all players due to the sound being played at their location, this commit fixes that issue by playing the sound at the item location.

This fix has been tested on a server running the latest version of Spigot (1.12.2-R0.1-SNAPSHOT) and ProtocolSupport (4.28-dev) with another player (1.12.2) and myself (1.7.10).