### PR TITLE
Update Glowstone version to latest to support 1.12.2.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ gen.mkdirs();
 task updateLibs(type: Download) {
 	src([
 		'https://yivesmirror.com/files/spigot/spigot-1.12.2-R0.1-SNAPSHOT-b1408.jar',
-		'https://repo.glowstone.net/content/repositories/snapshots/net/glowstone/glowstone/2017.9.0-SNAPSHOT/glowstone-2017.9.0-20170901.200134-1.jar'
+		'https://repo.glowstone.net/content/repositories/snapshots/net/glowstone/glowstone/2017.10.0-SNAPSHOT/glowstone-2017.10.0-20171007.064505-9.jar'
 	])
 	dest dllibs
 	onlyIfNewer true
@@ -101,7 +101,7 @@ repositories {
 }
 
 dependencies {
-	shadow files('buildprocessor/BuildProcessor.jar', new File(dllibs, 'spigot-1.12.2-R0.1-SNAPSHOT-b1408.jar'), new File(dllibs, 'glowstone-2017.9.0-20170901.200134-1.jar'))
+	shadow files('buildprocessor/BuildProcessor.jar', new File(dllibs, 'spigot-1.12.2-R0.1-SNAPSHOT-b1408.jar'), new File(dllibs, 'glowstone-2017.10.0-20171007.064505-9.jar'))
 	compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.0'
 	compile group: 'net.sf.trove4j', name: 'trove4j', version: '3.0.3'
 	compile group: 'com.google.code.gson', name: 'gson', version: '2.8.0'


### PR DESCRIPTION
Updated Glowstone from `2017.9.0` (1.12.1) to `2017.10.0` (1.12.2).

Looks like if you use a library for an older version, the compiler will 'cache' the server version (here: `GlowServer.GAME_VERSION`) instead of getting the actual version from the server. This means that using the latest ProtocolSupport with the latest Glowstone build will shutdown the server because the plugin thinks the version is 1.12.1 even though the server is on 1.12.2.

I don't know about gradle, but in Maven I think the `<scope>runtime</scope>` dependency tag would prevent this. Or maybe reflection would be more appropriate here.