### PR TITLE
Add "revert remap" when reading the ItemStack from the client, fixes remapped items from creative for PE clients

### DIFF
--- a/src/protocolsupport/protocol/serializer/ItemStackSerializer.java
+++ b/src/protocolsupport/protocol/serializer/ItemStackSerializer.java
@@ -20,6 +20,7 @@ import protocolsupport.api.ProtocolType;
 import protocolsupport.api.ProtocolVersion;
 import protocolsupport.api.events.ItemStackWriteEvent;
 import protocolsupport.protocol.typeremapper.itemstack.ItemStackRemapper;
+import protocolsupport.protocol.typeremapper.pe.PEDataValues;
 import protocolsupport.protocol.utils.NBTTagCompoundSerializer;
 import protocolsupport.utils.IntTuple;
 import protocolsupport.zplatform.ServerPlatform;
@@ -42,8 +43,16 @@ public class ItemStackSerializer {
 					return ItemStackWrapper.NULL;
 				}
 				int amountdata = VarNumberSerializer.readSVarInt(from);
+				int data = (amountdata >> 8) & 0xFFFF;
 				itemstack.setAmount(amountdata & 0x7F);
-				itemstack.setData((amountdata >> 8) & 0xFFFF);
+				itemstack.setData(data);
+				IntTuple itemAndData = PEDataValues.PE_ITEM_ID.getRemap(type, data);
+				if (itemAndData != null) {
+					itemstack.setTypeId(itemAndData.getI1());
+					if (itemAndData.getI2() != -1) {
+						itemstack.setData(itemAndData.getI2());
+					}
+				}
 				itemstack.setTag(readTag(from, false, version));
 				//TODO: Read the rest properly..
 				from.readByte();

--- a/src/protocolsupport/protocol/typeremapper/pe/PEDataValues.java
+++ b/src/protocolsupport/protocol/typeremapper/pe/PEDataValues.java
@@ -124,14 +124,18 @@ public class PEDataValues {
 	}
 
 	public static final RemappingTable.ComplexIdRemappingTable ITEM_ID = new RemappingTable.ComplexIdRemappingTable();
+	public static final RemappingTable.ComplexIdRemappingTable PE_ITEM_ID = new RemappingTable.ComplexIdRemappingTable();
 	private static void registerItemRemap(int from, int to) {
 		ITEM_ID.setSingleRemap(from, to, -1);
+		PE_ITEM_ID.setSingleRemap(to, from, -1);
 	}
 	private static void registerItemRemap(int from, int to, int dataTo) {
 		ITEM_ID.setSingleRemap(from, to, dataTo);
+		PE_ITEM_ID.setSingleRemap(to, from, dataTo);
 	}
 	private static void registerItemRemap(int from, int dataFrom, int to, int dataTo) {
 		ITEM_ID.setComplexRemap(from, dataFrom, to, dataTo);
+		PE_ITEM_ID.setComplexRemap(to, dataTo, from, dataFrom);
 	}
 
 	private static void registerBlockAndItemRemap(int from, int to) {


### PR DESCRIPTION
I tested, and it works:tm:

It creates a new remap table with the "reversed" values, containing the PE -> PC IDs.