### PR TITLE
Fix boneblock remap

### DIFF
--- a/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
+++ b/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
@@ -66,7 +66,7 @@ public class IdRemapper {
 			registerRemapEntry(Material.NETHER_WART_BLOCK, Material.WOOL, 14, ProtocolVersionsHelper.BEFORE_1_10);
 			registerRemapEntry(Material.RED_NETHER_BRICK, Material.NETHER_BRICK, ProtocolVersionsHelper.BEFORE_1_10);
 			registerRemapEntry(Material.MAGMA, Material.NETHERRACK, ProtocolVersionsHelper.BEFORE_1_10);
-			registerRemapEntry(Material.BONE_BLOCK, Material.BRICK, ProtocolVersionsHelper.BEFORE_1_10);
+			registerRemapEntry(Material.BONE_BLOCK, Material.BRICK, 0, ProtocolVersionsHelper.BEFORE_1_10);
 			for (int i = 0; i < MinecraftData.BLOCK_DATA_MAX; i++) {
 				int newdata = (i & 0x8) == 0x8 ? 1 : 0;
 				registerRemapEntry(Material.COMMAND_CHAIN, i, Material.COMMAND, newdata, ProtocolVersionsHelper.BEFORE_1_9);


### PR DESCRIPTION
Fixes the remap of the boneblock.

Currently for 1.8 and 1.9 clients it is air.

Currently (1.12.2 client):

![2017-11-08_19 56 53](https://user-images.githubusercontent.com/20865246/32568586-03c407be-c4bf-11e7-8d0b-ef90e8e9ee99.png)

Currently (1.8.9 client):

![2017-11-08_19 56 56](https://user-images.githubusercontent.com/20865246/32568574-f8f8342c-c4be-11e7-8457-e5717230a0f0.png)