### PR TITLE
Fix Boneblock ItemStack remap

### DIFF
--- a/src/protocolsupport/protocol/typeremapper/itemstack/ItemStackRemapper.java
+++ b/src/protocolsupport/protocol/typeremapper/itemstack/ItemStackRemapper.java
@@ -78,7 +78,7 @@ public class ItemStackRemapper {
 			registerRemapEntry(Material.NETHER_WART_BLOCK, Material.WOOL, 14, ProtocolVersionsHelper.BEFORE_1_10);
 			registerRemapEntry(Material.RED_NETHER_BRICK, Material.NETHER_BRICK, ProtocolVersionsHelper.BEFORE_1_10);
 			registerRemapEntry(Material.MAGMA, Material.NETHERRACK, ProtocolVersionsHelper.BEFORE_1_10);
-			registerRemapEntry(Material.BONE_BLOCK, Material.BRICK, ProtocolVersionsHelper.BEFORE_1_10);
+			registerRemapEntry(Material.BONE_BLOCK, Material.BRICK, 0, ProtocolVersionsHelper.BEFORE_1_10);
 			registerRemapEntry(Material.COMMAND_CHAIN, Material.COMMAND, ProtocolVersionsHelper.BEFORE_1_9);
 			registerRemapEntry(Material.COMMAND_REPEATING, Material.COMMAND, ProtocolVersionsHelper.BEFORE_1_9);
 			registerRemapEntry(Material.COMMAND, Material.COMMAND, ProtocolVersionsHelper.BEFORE_1_9);


### PR DESCRIPTION
Same thing as last time, just for the itemstack.

(Missed that last time)