### PR TITLE
[PSPE] Fix for BB & rounded position collision :wink:

### DIFF
--- a/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_pe/Position.java
+++ b/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_pe/Position.java
@@ -22,7 +22,9 @@ public class Position extends MiddlePosition {
 		if (!cache.isChunkMarkedAsSent(chunkX, chunkZ)) {
 			packets.add(Chunk.createEmptyChunk(version, chunkX, chunkZ));
 		}
-		packets.add(create(version, cache.getSelfPlayerEntityId(), x, y + 0.01, z, pitch, yaw, ANIMATION_MODE_TELEPORT));
+		if(cache.shouldResendPEClientPosition()) {
+			packets.add(create(version, cache.getSelfPlayerEntityId(), x, y + 0.01, z, pitch, yaw, ANIMATION_MODE_TELEPORT));
+		}
 		return packets;
 	}
 

--- a/src/protocolsupport/protocol/packet/middleimpl/serverbound/play/v_pe/PositionLook.java
+++ b/src/protocolsupport/protocol/packet/middleimpl/serverbound/play/v_pe/PositionLook.java
@@ -40,21 +40,17 @@ public class PositionLook extends ServerBoundMiddlePacket {
 	public RecyclableCollection<ServerBoundPacketData> toNative() {
 		RecyclableArrayList<ServerBoundPacketData> packets = RecyclableArrayList.create();
 		cache.updatePEPositionLeniency(y - cache.getClientY() > 0);
-		int freeTeleportId = cache.getTeleportConfirmIdForFree();
-		if (freeTeleportId != -1) {
-			if(!cache.shouldResendPEClientPosition()) {
-				//PE sends AVERAGE positions (FFS Mojang) so sometimes the BoundingBox of the player will collide inadvertently.
-				//We fake the servers position in this instance and shrug and resent a rounded position of the player so walking stairs ain't much an issue.
-				packets.add(MiddleTeleportAccept.create(freeTeleportId));
-				cache.payTeleportConfirm();
-				double[] serverPos = cache.getTeleportLocation();
-				packets.add(MiddlePositionLook.create(serverPos[0], serverPos[1], serverPos[2], yaw, pitch, true));
-				cache.setLastClientPosition(x, y, z);
-				x = Math.floor(x * 8) / 8; y = Math.ceil((y + 0.3) * 8) / 8; z = Math.floor(z * 8) / 8;
-				onGround = true;
-			} else if (cache.tryTeleportConfirm(x, y, z) != -1) {
-				packets.add(MiddleTeleportAccept.create(freeTeleportId));
-			}
+		int teleportId = cache.peekTeleportConfirmId();
+		if (teleportId != -1) {
+			//PE sends AVERAGE positions (FFS Mojang) so sometimes the BoundingBox of the player will collide inadvertently.
+			//We fake the servers position in this instance and shrug and resent a rounded position of the player.
+			packets.add(MiddleTeleportAccept.create(teleportId));
+			cache.payTeleportConfirm();
+			double[] serverPos = cache.getTeleportLocation();
+			packets.add(MiddlePositionLook.create(serverPos[0], serverPos[1], serverPos[2], yaw, pitch, onGround));
+			cache.setLastClientPosition(x, y, z);
+			//TODO: Play around more with these numbers to perhaps make things even more smooth.
+			x = Math.floor(x * 8) / 8; y = Math.ceil((y + 0.3) * 8) / 8; z = Math.floor(z * 8) / 8;
 		} else {
 			cache.setLastClientPosition(x, y, z);
 		}
@@ -62,7 +58,7 @@ public class PositionLook extends ServerBoundMiddlePacket {
 		packets.add(MiddlePositionLook.create(x, y, z, yaw, pitch, onGround));
 		
 
-		//TODO: remove this shit
+		//TODO: (re)move this shit
 		if (cache.getSignTag() != null) {
 			NBTTagCompoundWrapper signTag = cache.getSignTag();
 			int x = signTag.getIntNumber("x");

--- a/src/protocolsupport/protocol/storage/NetworkDataCache.java
+++ b/src/protocolsupport/protocol/storage/NetworkDataCache.java
@@ -47,7 +47,7 @@ public class NetworkDataCache {
 		return new double[] {x,y,z};
 	}
 	
-	public int getTeleportConfirmIdForFree() {
+	public int peekTeleportConfirmId() {
 		return teleportConfirmId;
 	}
 	

--- a/src/protocolsupport/protocol/storage/NetworkDataCache.java
+++ b/src/protocolsupport/protocol/storage/NetworkDataCache.java
@@ -42,12 +42,57 @@ public class NetworkDataCache {
 		}
 		return -1;
 	}
+	
+	public double[] getTeleportLocation() {
+		return new double[] {x,y,z};
+	}
+	
+	public int getTeleportConfirmIdForFree() {
+		return teleportConfirmId;
+	}
+	
+	public void payTeleportConfirm() {
+		this.teleportConfirmId = -1;
+	}
 
 	public void setTeleportLocation(double x, double y, double z, int teleportConfirmId) {
 		this.x = x;
 		this.y = y;
 		this.z = z;
 		this.teleportConfirmId = teleportConfirmId;
+	}
+	
+	//For pocket average position mess.
+	private final int leniencyMillis = 1000;
+	private double cX;
+	private double cY;
+	private double cZ;
+	private long leniencyMod;
+	private double pocketPositionLeniency = 0.5;
+	
+	public void setLastClientPosition(double x, double y, double z) {
+		this.cX = x;
+		this.cY = y;
+		this.cZ = z;
+	}
+	
+	public double getClientY() {
+		return cY;
+	}
+	
+	public void updatePEPositionLeniency(boolean loosenUp) {
+		if (loosenUp) {
+			pocketPositionLeniency = 3;
+			leniencyMod = System.currentTimeMillis();
+		} else if ((pocketPositionLeniency != 0.5) && (System.currentTimeMillis() - leniencyMod > leniencyMillis)) {
+			pocketPositionLeniency = 0.5;
+		}
+	}
+	
+	public boolean shouldResendPEClientPosition() {
+		return (Math.abs(cX - x) > pocketPositionLeniency) ||
+			   (Math.abs(cY - y) > pocketPositionLeniency) ||
+			   (Math.abs(cZ - z) > pocketPositionLeniency);
 	}
 
 	private WindowType windowType = WindowType.PLAYER;


### PR DESCRIPTION
The problem: PE sends rounded positions (based on the change it does itself). This is really irritating as it intersects with boundingboxes or so the server thinks.

The way the fix works is it fakes a position apology to the server if the server sends a teleport that is within the leniency. This leniency is standard 0.5 blocks, which makes you just able to walk up a halfslab. When running up stairs of any sort (halfstairs, stairs cakeblocks etc etc), however, you sometimes skim through the BB of that for more than 0.5 blocks. So when you are moving up, the leniency of the position is set to 3 blocks.
