### PR TITLE
Fix encryption in pipeline for Glowstone

### DIFF
--- a/src/protocolsupport/protocol/packet/handler/AbstractLoginListener.java
+++ b/src/protocolsupport/protocol/packet/handler/AbstractLoginListener.java
@@ -197,15 +197,7 @@ public abstract class AbstractLoginListener implements IHasProfile {
 
 	protected void enableEncryption(SecretKey key) {
 		ChannelPipeline pipeline = networkManager.getChannel().pipeline();
-		if (ServerPlatform.get().getIdentifier() == ServerPlatformIdentifier.GLOWSTONE) {
-			pipeline.addBefore(GlowStoneChannelHandlers.FRAMING, ChannelHandlers.ENCRYPT, new PacketEncrypter(MinecraftEncryption.getCipher(Cipher.ENCRYPT_MODE, key)));
-			pipeline.addBefore(ChannelHandlers.ENCRYPT, ChannelHandlers.DECRYPT, new PacketDecrypter(MinecraftEncryption.getCipher(Cipher.DECRYPT_MODE, key)));
-		} else {
-			pipeline.addBefore(SpigotChannelHandlers.SPLITTER, ChannelHandlers.DECRYPT, new PacketDecrypter(MinecraftEncryption.getCipher(Cipher.DECRYPT_MODE, key)));
-			if (isFullEncryption(connection.getVersion())) {
-				pipeline.addBefore(SpigotChannelHandlers.PREPENDER, ChannelHandlers.ENCRYPT, new PacketEncrypter(MinecraftEncryption.getCipher(Cipher.ENCRYPT_MODE, key)));
-			}
-		}
+		ServerPlatform.get().getMiscUtils().enableEncryption(pipeline, key, isFullEncryption(connection.getVersion()));
 	}
 
 	@SuppressWarnings("unchecked")

--- a/src/protocolsupport/protocol/packet/handler/AbstractLoginListener.java
+++ b/src/protocolsupport/protocol/packet/handler/AbstractLoginListener.java
@@ -1,48 +1,32 @@
 package protocolsupport.protocol.packet.handler;
 
-import java.security.PrivateKey;
-import java.text.MessageFormat;
-import java.util.Arrays;
-import java.util.UUID;
-import java.util.concurrent.Executor;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ThreadLocalRandom;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
-
-import javax.crypto.Cipher;
-import javax.crypto.SecretKey;
-
-import net.glowstone.net.pipeline.CompressionHandler;
-import org.apache.commons.lang3.Validate;
-import org.bukkit.Bukkit;
-
 import com.google.common.base.Charsets;
-
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelPipeline;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
+import org.apache.commons.lang3.Validate;
+import org.bukkit.Bukkit;
 import protocolsupport.ProtocolSupport;
 import protocolsupport.api.Connection;
 import protocolsupport.api.ProtocolType;
 import protocolsupport.api.ProtocolVersion;
-import protocolsupport.api.ServerPlatformIdentifier;
 import protocolsupport.api.events.PlayerLoginStartEvent;
 import protocolsupport.api.events.PlayerPropertiesResolveEvent.ProfileProperty;
 import protocolsupport.protocol.ConnectionImpl;
-import protocolsupport.protocol.pipeline.ChannelHandlers;
-import protocolsupport.protocol.pipeline.common.PacketDecrypter;
-import protocolsupport.protocol.pipeline.common.PacketEncrypter;
-import protocolsupport.protocol.utils.MinecraftEncryption;
 import protocolsupport.protocol.utils.authlib.GameProfile;
 import protocolsupport.utils.Utils;
 import protocolsupport.zplatform.ServerPlatform;
-import protocolsupport.zplatform.impl.glowstone.network.GlowStoneChannelHandlers;
-import protocolsupport.zplatform.impl.spigot.network.SpigotChannelHandlers;
 import protocolsupport.zplatform.network.NetworkManagerWrapper;
+
+import javax.crypto.SecretKey;
+import java.security.PrivateKey;
+import java.text.MessageFormat;
+import java.util.Arrays;
+import java.util.UUID;
+import java.util.concurrent.*;
+import java.util.logging.Level;
 
 public abstract class AbstractLoginListener implements IHasProfile {
 

--- a/src/protocolsupport/protocol/packet/handler/AbstractLoginListener.java
+++ b/src/protocolsupport/protocol/packet/handler/AbstractLoginListener.java
@@ -198,8 +198,8 @@ public abstract class AbstractLoginListener implements IHasProfile {
 	protected void enableEncryption(SecretKey key) {
 		ChannelPipeline pipeline = networkManager.getChannel().pipeline();
 		if (ServerPlatform.get().getIdentifier() == ServerPlatformIdentifier.GLOWSTONE) {
-			pipeline.addBefore(GlowStoneChannelHandlers.FRAMING, ChannelHandlers.ENCRYPT, new PacketDecrypter(MinecraftEncryption.getCipher(Cipher.DECRYPT_MODE, key)));
-			pipeline.addBefore(ChannelHandlers.ENCRYPT, ChannelHandlers.DECRYPT, new PacketDecrypter(MinecraftEncryption.getCipher(Cipher.ENCRYPT_MODE, key)));
+			pipeline.addBefore(GlowStoneChannelHandlers.FRAMING, ChannelHandlers.ENCRYPT, new PacketEncrypter(MinecraftEncryption.getCipher(Cipher.ENCRYPT_MODE, key)));
+			pipeline.addBefore(ChannelHandlers.ENCRYPT, ChannelHandlers.DECRYPT, new PacketDecrypter(MinecraftEncryption.getCipher(Cipher.DECRYPT_MODE, key)));
 		} else {
 			pipeline.addBefore(SpigotChannelHandlers.SPLITTER, ChannelHandlers.DECRYPT, new PacketDecrypter(MinecraftEncryption.getCipher(Cipher.DECRYPT_MODE, key)));
 			if (isFullEncryption(connection.getVersion())) {

--- a/src/protocolsupport/zplatform/PlatformUtils.java
+++ b/src/protocolsupport/zplatform/PlatformUtils.java
@@ -15,6 +15,8 @@ import protocolsupport.protocol.pipeline.IPacketPrepender;
 import protocolsupport.protocol.pipeline.IPacketSplitter;
 import protocolsupport.zplatform.itemstack.NBTTagCompoundWrapper;
 
+import javax.crypto.SecretKey;
+
 public interface PlatformUtils {
 
 	public ItemStack createItemStackFromNBTTag(NBTTagCompoundWrapper tag);
@@ -52,6 +54,8 @@ public interface PlatformUtils {
 	public String getReadTimeoutHandlerName();
 
 	public void enableCompression(ChannelPipeline pipeline, int compressionThreshold);
+
+	public void enableEncryption(ChannelPipeline pipeline, SecretKey key, boolean fullEncryption);
 
 	public void setFraming(ChannelPipeline pipeline, IPacketSplitter splitter, IPacketPrepender prepender);
 

--- a/src/protocolsupport/zplatform/impl/glowstone/GlowStoneMiscUtils.java
+++ b/src/protocolsupport/zplatform/impl/glowstone/GlowStoneMiscUtils.java
@@ -23,8 +23,12 @@ import net.glowstone.net.pipeline.MessageHandler;
 import net.glowstone.net.protocol.ProtocolType;
 import net.glowstone.util.GlowServerIcon;
 import protocolsupport.api.utils.NetworkState;
+import protocolsupport.protocol.pipeline.ChannelHandlers;
 import protocolsupport.protocol.pipeline.IPacketPrepender;
 import protocolsupport.protocol.pipeline.IPacketSplitter;
+import protocolsupport.protocol.pipeline.common.PacketDecrypter;
+import protocolsupport.protocol.pipeline.common.PacketEncrypter;
+import protocolsupport.protocol.utils.MinecraftEncryption;
 import protocolsupport.protocol.utils.authlib.GameProfile;
 import protocolsupport.utils.ReflectionUtils;
 import protocolsupport.zplatform.PlatformUtils;
@@ -32,6 +36,9 @@ import protocolsupport.zplatform.impl.glowstone.itemstack.GlowStoneNBTTagCompoun
 import protocolsupport.zplatform.impl.glowstone.network.GlowStoneChannelHandlers;
 import protocolsupport.zplatform.impl.glowstone.network.pipeline.GlowStoneFramingHandler;
 import protocolsupport.zplatform.itemstack.NBTTagCompoundWrapper;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
 
 public class GlowStoneMiscUtils implements PlatformUtils {
 
@@ -198,6 +205,12 @@ public class GlowStoneMiscUtils implements PlatformUtils {
 	@Override
 	public void enableCompression(ChannelPipeline pipeline, int compressionThreshold) {
 		pipeline.addAfter(GlowStoneChannelHandlers.FRAMING, "compression", new CompressionHandler(compressionThreshold));
+	}
+
+	@Override
+	public void enableEncryption(ChannelPipeline pipeline, SecretKey key, boolean fullEncryption) {
+		pipeline.addBefore(GlowStoneChannelHandlers.FRAMING, ChannelHandlers.ENCRYPT, new PacketEncrypter(MinecraftEncryption.getCipher(Cipher.ENCRYPT_MODE, key)));
+		pipeline.addBefore(ChannelHandlers.ENCRYPT, ChannelHandlers.DECRYPT, new PacketDecrypter(MinecraftEncryption.getCipher(Cipher.DECRYPT_MODE, key)));
 	}
 
 	@Override

--- a/src/protocolsupport/zplatform/impl/glowstone/GlowStoneMiscUtils.java
+++ b/src/protocolsupport/zplatform/impl/glowstone/GlowStoneMiscUtils.java
@@ -209,8 +209,10 @@ public class GlowStoneMiscUtils implements PlatformUtils {
 
 	@Override
 	public void enableEncryption(ChannelPipeline pipeline, SecretKey key, boolean fullEncryption) {
-		pipeline.addBefore(GlowStoneChannelHandlers.FRAMING, ChannelHandlers.ENCRYPT, new PacketEncrypter(MinecraftEncryption.getCipher(Cipher.ENCRYPT_MODE, key)));
-		pipeline.addBefore(ChannelHandlers.ENCRYPT, ChannelHandlers.DECRYPT, new PacketDecrypter(MinecraftEncryption.getCipher(Cipher.DECRYPT_MODE, key)));
+		pipeline.addBefore(GlowStoneChannelHandlers.FRAMING, ChannelHandlers.DECRYPT, new PacketDecrypter(MinecraftEncryption.getCipher(Cipher.DECRYPT_MODE, key)));
+		if (fullEncryption) {
+			pipeline.addBefore(GlowStoneChannelHandlers.FRAMING, ChannelHandlers.ENCRYPT, new PacketEncrypter(MinecraftEncryption.getCipher(Cipher.ENCRYPT_MODE, key)));
+		}
 	}
 
 	@Override

--- a/src/protocolsupport/zplatform/impl/glowstone/injector/GlowStoneServerConnectionChannel.java
+++ b/src/protocolsupport/zplatform/impl/glowstone/injector/GlowStoneServerConnectionChannel.java
@@ -34,9 +34,9 @@ public class GlowStoneServerConnectionChannel extends ChannelInitializer {
 		connection.storeInChannel(channel);
 		ProtocolStorage.addConnection(channel.remoteAddress(), connection);
 		pipeline.remove(GlowStoneChannelHandlers.READ_TIMEOUT);
-		pipeline.remove("legacy_ping");
-		pipeline.remove("encryption");
-		pipeline.remove("compression");
+		pipeline.remove(GlowStoneChannelHandlers.LEGACY_PING);
+		pipeline.remove(GlowStoneChannelHandlers.ENCRYPTION);
+		pipeline.remove(GlowStoneChannelHandlers.COMPRESSION);
 		pipeline.addFirst(GlowStoneChannelHandlers.READ_TIMEOUT, new SimpleReadTimeoutHandler(30));
 		pipeline.addAfter(GlowStoneChannelHandlers.READ_TIMEOUT, ChannelHandlers.INITIAL_DECODER, new InitialPacketDecoder());
 		pipeline.addBefore(GlowStoneChannelHandlers.NETWORK_MANAGER, "ps_glowstone_sync_ticker", GlowStoneSyncTickerStarter.INSTANCE);

--- a/src/protocolsupport/zplatform/impl/glowstone/network/GlowStoneChannelHandlers.java
+++ b/src/protocolsupport/zplatform/impl/glowstone/network/GlowStoneChannelHandlers.java
@@ -4,8 +4,9 @@ public class GlowStoneChannelHandlers {
 
 	public static final String READ_TIMEOUT = "idle_timeout";
 	public static final String FRAMING = "framing";
-	public static final String DECODER_ENCODER = "codecs";
 	public static final String NETWORK_MANAGER = "handler";
-	public static final String DECRYPT = "decrypt";
+	public static final String LEGACY_PING = "legacy_ping";
+	public static final String COMPRESSION = "compression";
+	public static final String ENCRYPTION = "encryption";
 
 }


### PR DESCRIPTION
It looks like encryption was only working for the Spigot pipeline, so I added a check for Glowstone and replicated the correct order for GS's channel pipeline.

~After this fix, a client receiving a chat packet (0x0F), like the join message, will crash. I'm not sure if this is caused by this particular fix or by another issue in ProtocolSupport.~ This is fixed, I swapped the encryption/decryption modes by accident.