### PR TITLE
Use abs time in <= 1.5.2

### DIFF
--- a/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_4_5_6_7_8_9r1_9r2_10_11_12r1_12r2/TimeUpdate.java
+++ b/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_4_5_6_7_8_9r1_9r2_10_11_12r1_12r2/TimeUpdate.java
@@ -13,7 +13,7 @@ public class TimeUpdate extends MiddleTimeUpdate {
 	public RecyclableCollection<ClientBoundPacketData> toData() {
 		ProtocolVersion version = connection.getVersion();
 		ClientBoundPacketData serializer = ClientBoundPacketData.create(ClientBoundPacket.PLAY_UPDATE_TIME_ID, version);
-		if (version.isBeforeOrEq(ProtocolVersion.MINECRAFT_1_4_7)) {
+		if (version.isBeforeOrEq(ProtocolVersion.MINECRAFT_1_5_2)) {
 			timeOfDay = Math.abs(timeOfDay);
 		}
 		serializer.writeLong(worldAge);


### PR DESCRIPTION
Flicker problem is in 1.5.2 too.
and 1.6.4 or later is not