### PR TITLE
Update GlowStoneNetworkManagerWrapper.java

### DIFF
--- a/src/protocolsupport/zplatform/impl/glowstone/network/GlowStoneNetworkManagerWrapper.java
+++ b/src/protocolsupport/zplatform/impl/glowstone/network/GlowStoneNetworkManagerWrapper.java
@@ -39,7 +39,7 @@ public class GlowStoneNetworkManagerWrapper extends NetworkManagerWrapper {
 	}
 
 	public GlowSession getSession() {
-		return handler.getSession().get();
+		return handler.getSession();
 	}
 
 	@Override


### PR DESCRIPTION
MessageHandler.getSession() now returns GlowSession, not AtomicReference<>, per https://github.com/GlowstoneMC/Glowstone/commit/5201a8ca95a56cfe70657afaea96ba540787233d#diff-94c1b6bbf29c46363389e03934b3fe81. Be sure to pull that change if testing this PR manually or if automated tests fail.