### PR TITLE
Set java.awt.headless to true to disable app window on macos.

### DIFF
--- a/src/protocolsupport/ProtocolSupport.java
+++ b/src/protocolsupport/ProtocolSupport.java
@@ -71,6 +71,7 @@ public class ProtocolSupport extends JavaPlugin {
 	@Override
 	public void onLoad() {
 		try {
+			System.setProperty("java.awt.headless", "true");
 			buildinfo = new BuildInfo();
 		} catch (Throwable t) {
 			getLogger().severe("Unable to load buildinfo, make sure you built this version using Gradle");


### PR DESCRIPTION
When running on macosx, an app window (icon + menues) appear from Spigot when loading the PS plugin. This is due to the fact that a few classes in PS utilise AWT, such as java.awt.Color. As soon as you use any AWT, it starts loading a lot of GUI stuff. Most of it can be disabled by setting the property java.awt.headless to true.

I'm not sure this is a good placement of the code, but I found no good init() function to put it in.