### PR TITLE
Set java.awt.headless to true to disable app window on macos

### DIFF
--- a/src/protocolsupport/ProtocolSupport.java
+++ b/src/protocolsupport/ProtocolSupport.java
@@ -51,6 +51,8 @@ public class ProtocolSupport extends JavaPlugin {
 
 	public ProtocolSupport() {
 		instance = this;
+		// Make sure our use of AWT do not trigger GUI components to start
+		System.setProperty("java.awt.headless", "true");
 	}
 
 	private BuildInfo buildinfo;


### PR DESCRIPTION
New attempt, in correct branch and recommended placement.