### PR TITLE
Fix pe time update when dodaylightcycle false

### DIFF
--- a/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_pe/TimeUpdate.java
+++ b/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_pe/TimeUpdate.java
@@ -12,7 +12,7 @@ public class TimeUpdate extends MiddleTimeUpdate {
 	@Override
 	public RecyclableCollection<ClientBoundPacketData> toData() {
 		ClientBoundPacketData serializer = ClientBoundPacketData.create(PEPacketIDs.UPDATE_TIME, connection.getVersion());
-		VarNumberSerializer.writeSVarInt(serializer, (int) (worldAge % Integer.MAX_VALUE));
+		VarNumberSerializer.writeSVarInt(serializer, (int) Math.abs(timeOfDay));
 		return RecyclableSingletonList.create(serializer);
 	}
 


### PR DESCRIPTION
First `worldAge` is wrong. It will led time past when dodaylightcycle=false.

Spigot flip the time when do dodaylightcycle false. PE has different behevior with PC when time < 0. So we need flip it again.

```
    public PacketPlayOutUpdateTime(long var1, long var3, boolean var5) {
        this.a = var1;
        this.b = var3;
        if (!var5) {
            this.b = -this.b;
            if (this.b == 0L) {
                this.b = -1L;
            }
        }

    }

```

