### PR TITLE
Allow JitPack to find the output jar by copying it

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,10 +31,7 @@ tasks.withType(JavaCompile) {
 
 group 'protocolsupport'
 version '4.29-dev'
-sourceCompatibility = 1.8
-
-
-import java.text.MessageFormat
+sourceCompatibility = JavaVersion.VERSION_1_8
 
 import java.text.MessageFormat
 
@@ -144,6 +141,15 @@ task generateInfo(type: DefaultTask) {doLast{
 	new FileOutputStream(buildInfoFile).withCloseable({ properties.store(it, "Build info") })
 }}
 
+task copyFinalJarToTarget(type: Copy) {
+	// JitPack searches for the output jar at the standard Gradle output directory (jar.archivePath)
+	// By copying it from there to our target destination JitPack can archive it in a Maven repository
+	from jar.archivePath.getPath()
+	into 'target'
+
+	//remove version suffix
+	rename (jar.archiveName, jar.baseName + '.jar')
+}
 
 shadowJar {
 	doFirst {
@@ -154,10 +160,9 @@ shadowJar {
 	from 'LICENSE'
 	from genDir
 
+	//remove the -all suffix
+	archiveName = jar.archiveName
 	minimizeJar = true
-
-	destinationDir = file('target')
-	archiveName = 'ProtocolSupport.jar'
 
 	exclude 'META-INF/**'
 	relocate 'org.apache', 'protocolsupport.libs.org.apache'
@@ -173,3 +178,4 @@ jar.enabled = false
 jar.finalizedBy(shadowJar)
 shadowJar.dependsOn(generateInfo)
 shadowJar.dependsOn(generateLocaleList)
+shadowJar.finalizedBy(copyFinalJarToTarget)


### PR DESCRIPTION
(Related #787)

This builds the jar to the normal Gradle output directory (with normal project name and version suffix) and copies it after it to target/ProtocolSupport.jar (without version suffix).

JitPack builds:
[Build log](https://jitpack.io/com/github/games647/ProtocolSupport/jitpack-7c18ea65ca-1/build.log)
[Output jar](https://jitpack.io/com/github/games647/ProtocolSupport/jitpack-7c18ea65ca-1/ProtocolSupport-jitpack-7c18ea65ca-1.jar)

Other project can then use something like this.
```xml
	<repositories>
		<repository>
		    <id>jitpack.io</id>
		    <url>https://jitpack.io</url>
		</repository>
	</repositories>
```

```xml
	<dependency>
	    <groupId>com.github.games647</groupId>
	    <artifactId>ProtocolSupport</artifactId>
            <!-- 4.29-dev -->
	    <version>jitpack-7c18ea65ca-1</version>
	</dependency>
```

For versioning you could tag each new released version using Git. Then we could replace the commit hash with the actual version representation like this below.

```xml
	<dependency>
	    <groupId>com.github.games647</groupId>
	    <artifactId>ProtocolSupport</artifactId>
	    <version>4.29-dev</version>
	</dependency>
```
