### PR TITLE
Sound name size make to <= 32

### DIFF
--- a/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_4_5_6_7_8/WorldCustomSound.java
+++ b/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_4_5_6_7_8/WorldCustomSound.java
@@ -5,6 +5,7 @@ import protocolsupport.protocol.packet.ClientBoundPacket;
 import protocolsupport.protocol.packet.middle.clientbound.play.MiddleWorldCustomSound;
 import protocolsupport.protocol.packet.middleimpl.ClientBoundPacketData;
 import protocolsupport.protocol.serializer.StringSerializer;
+import protocolsupport.utils.Utils;
 import protocolsupport.utils.recyclable.RecyclableCollection;
 import protocolsupport.utils.recyclable.RecyclableSingletonList;
 
@@ -14,8 +15,8 @@ public class WorldCustomSound extends MiddleWorldCustomSound {
 	public RecyclableCollection<ClientBoundPacketData> toData() {
 		ProtocolVersion version = connection.getVersion();
 		ClientBoundPacketData serializer = ClientBoundPacketData.create(ClientBoundPacket.PLAY_WORLD_CUSTOM_SOUND_ID);
-		if (version.isBeforeOrEq(ProtocolVersion.MINECRAFT_1_5_2) && id.length() > 32) {
-			id = id.substring(0, 32);
+		if (version.isBeforeOrEq(ProtocolVersion.MINECRAFT_1_5_2)) {
+			id = Utils.clampString(id, 32);
 		}
 		StringSerializer.writeString(serializer, version, id);
 		serializer.writeInt(x);

--- a/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_4_5_6_7_8/WorldCustomSound.java
+++ b/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_4_5_6_7_8/WorldCustomSound.java
@@ -14,6 +14,9 @@ public class WorldCustomSound extends MiddleWorldCustomSound {
 	public RecyclableCollection<ClientBoundPacketData> toData() {
 		ProtocolVersion version = connection.getVersion();
 		ClientBoundPacketData serializer = ClientBoundPacketData.create(ClientBoundPacket.PLAY_WORLD_CUSTOM_SOUND_ID);
+		if (version.isBeforeOrEq(ProtocolVersion.MINECRAFT_1_5_2)) {
+			id = id.substring(0, Math.min(id.length(), 32));
+		}
 		StringSerializer.writeString(serializer, version, id);
 		serializer.writeInt(x);
 		serializer.writeInt(y);

--- a/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_4_5_6_7_8/WorldCustomSound.java
+++ b/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_4_5_6_7_8/WorldCustomSound.java
@@ -14,8 +14,8 @@ public class WorldCustomSound extends MiddleWorldCustomSound {
 	public RecyclableCollection<ClientBoundPacketData> toData() {
 		ProtocolVersion version = connection.getVersion();
 		ClientBoundPacketData serializer = ClientBoundPacketData.create(ClientBoundPacket.PLAY_WORLD_CUSTOM_SOUND_ID);
-		if (version.isBeforeOrEq(ProtocolVersion.MINECRAFT_1_5_2)) {
-			id = id.substring(0, Math.min(id.length(), 32));
+		if (version.isBeforeOrEq(ProtocolVersion.MINECRAFT_1_5_2) && id.length() > 32) {
+			id = id.substring(0, 32);
 		}
 		StringSerializer.writeString(serializer, version, id);
 		serializer.writeInt(x);


### PR DESCRIPTION
If name size more than 32, would be crash in 1.4.7 & 1.5.2. but 1.6 or higher isn't.
Is this correct way for solve that?