### PR TITLE
Particle count make to <= 1

### DIFF
--- a/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_5_6_7/WorldParticle.java
+++ b/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_5_6_7/WorldParticle.java
@@ -48,7 +48,7 @@ public class WorldParticle extends MiddleWorldParticle {
 		serializer.writeFloat(offY);
 		serializer.writeFloat(offZ);
 		serializer.writeFloat(speed);
-		serializer.writeInt(count);
+		serializer.writeInt(Math.max(count, 1));
 		return RecyclableSingletonList.create(serializer);
 	}
 


### PR DESCRIPTION
Can see particle even if particle count is 0 in 1.7 or higher. but <= 1.6 isn't
In 1.7 or higher, particle count 0 work like 1. if less than 0, not displayed.

Should I check version <= 1.6 and count is 0? or just keep this code?