### PR TITLE
Fix minecart issue

### DIFF
--- a/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_4_5/VehiclePassengers.java
+++ b/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_4_5/VehiclePassengers.java
@@ -4,12 +4,14 @@ import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
 import protocolsupport.protocol.packet.ClientBoundPacket;
 import protocolsupport.protocol.packet.middle.clientbound.play.MiddleVehiclePassengers;
 import protocolsupport.protocol.packet.middleimpl.ClientBoundPacketData;
+import protocolsupport.protocol.storage.netcache.WatchedEntityCache;
 import protocolsupport.utils.recyclable.RecyclableCollection;
 import protocolsupport.utils.recyclable.RecyclableSingletonList;
 
 public class VehiclePassengers extends MiddleVehiclePassengers {
 
 	protected final Int2IntOpenHashMap vehiclePassenger = new Int2IntOpenHashMap();
+	protected final Int2IntOpenHashMap passengerToVehicle = new Int2IntOpenHashMap();
 	protected int passengerId;
 
 	@Override
@@ -24,9 +26,19 @@ public class VehiclePassengers extends MiddleVehiclePassengers {
 	public boolean postFromServerRead() {
 		if (passengersIds.length == 0) {
 			passengerId = vehiclePassenger.remove(vehicleId);
+			passengerToVehicle.remove(passengerId);
 		} else {
 			passengerId = passengersIds[0];
 			vehiclePassenger.put(vehicleId, passengerId);
+		}
+		WatchedEntityCache entityCache = cache.getWatchedEntityCache();
+		if (passengersIds.length != 0 && entityCache.hasWatchedEntity(vehicleId) && entityCache.hasWatchedEntity(passengerId)) {
+			int prevVehicleId = passengerToVehicle.getOrDefault(passengerId, -1);
+			if (entityCache.hasWatchedEntity(prevVehicleId)) {
+				return false;
+			} else {
+				passengerToVehicle.put(passengerId, vehicleId);
+			}
 		}
 		return true;
 	}

--- a/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_4_5_6/SpawnObject.java
+++ b/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_4_5_6/SpawnObject.java
@@ -60,9 +60,7 @@ public class SpawnObject extends MiddleSpawnObject {
 				break;
 			}
 			case MINECART: {
-				if (version.isAfterOrEq(ProtocolVersion.MINECRAFT_1_6_1)) {
-					y += 16;
-				}
+				y += 16;
 				break;
 			}
 			default: {

--- a/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_4_5_6/SpawnObject.java
+++ b/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_4_5_6/SpawnObject.java
@@ -59,6 +59,12 @@ public class SpawnObject extends MiddleSpawnObject {
 				objectdata--;
 				break;
 			}
+			case MINECART: {
+				if (version.isAfterOrEq(ProtocolVersion.MINECRAFT_1_6_1)) {
+					y += 16;
+				}
+				break;
+			}
 			default: {
 				break;
 			}

--- a/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_7/SpawnObject.java
+++ b/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_7/SpawnObject.java
@@ -60,6 +60,10 @@ public class SpawnObject extends MiddleSpawnObject {
 				objectdata--;
 				break;
 			}
+			case MINECART: {
+				y += 16;
+				break;
+			}
 			default: {
 				break;
 			}

--- a/src/protocolsupport/protocol/storage/netcache/WatchedEntityCache.java
+++ b/src/protocolsupport/protocol/storage/netcache/WatchedEntityCache.java
@@ -32,6 +32,10 @@ public class WatchedEntityCache {
 		return watchedEntities.get(entityId);
 	}
 
+	public boolean hasWatchedEntity(int entityId) {
+		return watchedEntities.containsKey(entityId);
+	}
+
 	public void removeWatchedEntities(int[] entityIds) {
 		for (int entityId : entityIds) {
 			watchedEntities.remove(entityId);


### PR DESCRIPTION
> your player is rapidly switching between the "Sitting in minecart" and "Standing looking at minecart" positions. Because of this sometimes very rarely your player (the one in the minecart) gets teleported 2-3 blocks above the minecart and the game softlocks, as in everything is frozen except the chat (for that player).

**Couldn't reproduce but when non-passenger rejoin, passenger looks flying(minecart above 2~3blocks). This fixed**

> Commands that kill the frozen player make the bone-breaking sound and health flashes however it does not seem to decrease or have any other effect. Upon logging out and back in you get the "Game over" screen because the damage was actually applied and when you click respawn everything looks OK at first however other weird glitches arise such as you can't see projectiles in mid flight, falling sand disappears and re appears at bottom etc.

**Couldn't reproduce. but I found bug that can't respawn**

> For other players, the player in the minecart is rapidly appearing riding the minecart and switching to a position in which he is standing close to the minecart and looking at it (constantly). This can be verified by building a small minecart loop and running a cart inside it. The player riding the minecart switches between looping around and being at the center and spinning around looking at the minecart.

**Couldn't reproduce**

> If you stay in the minecart long enough (5 or 10 minutes) and press "Sneak" you might get a "End of stream" error

**Couldn't reproduce. tested 10m and 30m**

Did I miss anything?