### PR TITLE
Add missing PE entity IDs for new mobs (fish varietes, etc).

### DIFF
--- a/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_pe/SpawnLiving.java
+++ b/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_pe/SpawnLiving.java
@@ -69,7 +69,8 @@ public class SpawnLiving extends MiddleSpawnLiving {
 		ClientBoundPacketData serializer = ClientBoundPacketData.create(PEPacketIDs.SPAWN_ENTITY);
 		VarNumberSerializer.writeSVarLong(serializer, entity.getId());
 		VarNumberSerializer.writeVarLong(serializer, entity.getId());
-		VarNumberSerializer.writeVarInt(serializer, PEDataValues.getEntityTypeId(GenericIdRemapper.ENTITY.getTable(version).getRemap(entity.getType())));
+		NetworkEntityType entityType = GenericIdRemapper.ENTITY.getTable(version).getRemap(entity.getType());
+		VarNumberSerializer.writeVarInt(serializer, PEDataValues.getEntityTypeId(entityType));
 		serializer.writeFloatLE((float) x);
 		serializer.writeFloatLE((float) y);
 		serializer.writeFloatLE((float) z);

--- a/src/protocolsupport/protocol/typeremapper/pe/PEDataValues.java
+++ b/src/protocolsupport/protocol/typeremapper/pe/PEDataValues.java
@@ -93,6 +93,18 @@ public class PEDataValues {
 		registerLivingType(NetworkEntityType.EVOKER, 104);
 		registerLivingType(NetworkEntityType.VEX, 105);
 
+		registerLivingType(NetworkEntityType.DOLPHIN, 31);
+		registerLivingType(NetworkEntityType.PUFFERFISH, 108);
+		registerLivingType(NetworkEntityType.SALMON, 109);
+		registerLivingType(NetworkEntityType.TROPICAL_FISH, 111);
+		registerLivingType(NetworkEntityType.COD, 112);
+		registerLivingType(NetworkEntityType.DROWNED, 110);
+
+		// FIXME: Figure out correct value; for now use SQUID (17) to avoid crash
+		registerLivingType(NetworkEntityType.PHANTOM, 17);
+		registerLivingType(NetworkEntityType.DOLPHIN, 17);
+		registerLivingType(NetworkEntityType.TURTLE, 17);
+
 		entityType.put(NetworkEntityType.ARMOR_STAND_OBJECT, 61);
 		entityType.put(NetworkEntityType.TNT, 65);
 		entityType.put(NetworkEntityType.FALLING_OBJECT, 66);

--- a/src/protocolsupport/protocol/typeremapper/pe/PEDataValues.java
+++ b/src/protocolsupport/protocol/typeremapper/pe/PEDataValues.java
@@ -100,11 +100,6 @@ public class PEDataValues {
 		registerLivingType(NetworkEntityType.COD, 112);
 		registerLivingType(NetworkEntityType.DROWNED, 110);
 
-		// FIXME: Figure out correct value; for now use SQUID (17) to avoid crash
-		registerLivingType(NetworkEntityType.PHANTOM, 17);
-		registerLivingType(NetworkEntityType.DOLPHIN, 17);
-		registerLivingType(NetworkEntityType.TURTLE, 17);
-
 		entityType.put(NetworkEntityType.ARMOR_STAND_OBJECT, 61);
 		entityType.put(NetworkEntityType.TNT, 65);
 		entityType.put(NetworkEntityType.FALLING_OBJECT, 66);
@@ -114,6 +109,7 @@ public class PEDataValues {
 		entityType.put(NetworkEntityType.ENDEREYE, 70);
 		entityType.put(NetworkEntityType.ENDER_CRYSTAL, 71);
 		entityType.put(NetworkEntityType.FIREWORK, 72);
+		entityType.put(NetworkEntityType.THROWN_TRIDENT, 73);
 		entityType.put(NetworkEntityType.SHULKER_BULLET, 76);
 		entityType.put(NetworkEntityType.FISHING_FLOAT, 77);
 		entityType.put(NetworkEntityType.DRAGON_FIREBALL, 79);


### PR DESCRIPTION
Unfortunately, I've not yet been able to determine correct IDs for all types. But without any mapping at all, we crash with NPE when the entity spawn. :(