### PR TITLE
Fixes some mappings for pre-existing blocks

### DIFF
--- a/resources/resources/mappings/preflatteningblockiddata.json
+++ b/resources/resources/mappings/preflatteningblockiddata.json
@@ -410,6 +410,66 @@
     "legacydata": 11
   },
   {
+    "blockdata": "minecraft:oak_wood[axis=x]",
+    "legacyid": 17,
+    "legacydata": 12
+  },
+  {
+    "blockdata": "minecraft:spruce_wood[axis=x]",
+    "legacyid": 17,
+    "legacydata": 13
+  },
+  {
+    "blockdata": "minecraft:birch_wood[axis=x]",
+    "legacyid": 17,
+    "legacydata": 14
+  },
+  {
+    "blockdata": "minecraft:jungle_wood[axis=x]",
+    "legacyid": 17,
+    "legacydata": 15
+  },
+  {
+    "blockdata": "minecraft:oak_wood[axis=y]",
+    "legacyid": 17,
+    "legacydata": 12
+  },
+  {
+    "blockdata": "minecraft:spruce_wood[axis=y]",
+    "legacyid": 17,
+    "legacydata": 13
+  },
+  {
+    "blockdata": "minecraft:birch_wood[axis=y]",
+    "legacyid": 17,
+    "legacydata": 14
+  },
+  {
+    "blockdata": "minecraft:jungle_wood[axis=y]",
+    "legacyid": 17,
+    "legacydata": 15
+  },
+  {
+    "blockdata": "minecraft:oak_wood[axis=z]",
+    "legacyid": 17,
+    "legacydata": 12
+  },
+  {
+    "blockdata": "minecraft:spruce_wood[axis=z]",
+    "legacyid": 17,
+    "legacydata": 13
+  },
+  {
+    "blockdata": "minecraft:birch_wood[axis=z]",
+    "legacyid": 17,
+    "legacydata": 14
+  },
+  {
+    "blockdata": "minecraft:jungle_wood[axis=z]",
+    "legacyid": 17,
+    "legacydata": 15
+  },
+  {
     "blockdata": "minecraft:oak_leaves[distance=7,persistent=false]",
     "legacyid": 18,
     "legacydata": 0
@@ -5106,6 +5166,36 @@
   },
   {
     "blockdata": "minecraft:dark_oak_log[axis=z]",
+    "legacyid": 162,
+    "legacydata": 9
+  },
+  {
+    "blockdata": "minecraft:acacia_wood[axis=y]",
+    "legacyid": 162,
+    "legacydata": 0
+  },
+  {
+    "blockdata": "minecraft:dark_oak_wood[axis=y]",
+    "legacyid": 162,
+    "legacydata": 1
+  },
+  {
+    "blockdata": "minecraft:acacia_wood[axis=x]",
+    "legacyid": 162,
+    "legacydata": 4
+  },
+  {
+    "blockdata": "minecraft:dark_oak_wood[axis=x]",
+    "legacyid": 162,
+    "legacydata": 5
+  },
+  {
+    "blockdata": "minecraft:acacia_wood[axis=z]",
+    "legacyid": 162,
+    "legacydata": 8
+  },
+  {
+    "blockdata": "minecraft:dark_oak_wood[axis=z]",
     "legacyid": 162,
     "legacydata": 9
   },

--- a/src/protocolsupport/protocol/typeremapper/block/LegacyBlockData.java
+++ b/src/protocolsupport/protocol/typeremapper/block/LegacyBlockData.java
@@ -146,8 +146,8 @@ public class LegacyBlockData {
 					Material.JUNGLE_LEAVES, Material.SPRUCE_LEAVES, Material.OAK_LEAVES,
 					Material.ACACIA_FENCE, Material.DARK_OAK_FENCE, Material.BIRCH_FENCE,
 					Material.JUNGLE_FENCE, Material.SPRUCE_FENCE, Material.OAK_FENCE,
-					Material.IRON_BARS,
-					Material.CHORUS_PLANT, Material.MUSHROOM_STEM, Material.BROWN_MUSHROOM_BLOCK, Material.GLASS_PANE,
+					Material.NETHER_BRICK_FENCE, Material.IRON_BARS,
+					Material.CHORUS_PLANT, Material.MUSHROOM_STEM, Material.BROWN_MUSHROOM_BLOCK, Material.RED_MUSHROOM_BLOCK, Material.GLASS_PANE,
 					Material.BLACK_STAINED_GLASS_PANE, Material.BLUE_STAINED_GLASS_PANE, Material.BROWN_STAINED_GLASS_PANE, Material.CYAN_STAINED_GLASS_PANE,
 					Material.GRAY_STAINED_GLASS_PANE, Material.GREEN_STAINED_GLASS_PANE, Material.LIGHT_BLUE_STAINED_GLASS_PANE, Material.LIGHT_GRAY_STAINED_GLASS_PANE,
 					Material.LIME_STAINED_GLASS_PANE, Material.MAGENTA_STAINED_GLASS_PANE, Material.ORANGE_STAINED_GLASS_PANE, Material.PINK_STAINED_GLASS_PANE,
@@ -211,7 +211,9 @@ public class LegacyBlockData {
 				Arrays.asList(
 					Material.ACACIA_SLAB, Material.DARK_OAK_SLAB, Material.BIRCH_SLAB,
 					Material.JUNGLE_SLAB, Material.OAK_SLAB, Material.SPRUCE_SLAB,
-					Material.COBBLESTONE_SLAB, Material.SANDSTONE_SLAB, Material.RED_SANDSTONE_SLAB
+					Material.COBBLESTONE_SLAB, Material.SANDSTONE_SLAB, Material.RED_SANDSTONE_SLAB,
+					Material.STONE_SLAB, Material.BRICK_SLAB, Material.STONE_BRICK_SLAB,
+					Material.NETHER_BRICK_SLAB, Material.QUARTZ_SLAB, Material.PURPUR_SLAB
 				),
 				o -> toPre13SlabState(o, (Slab) o.getMaterial().createBlockData()),
 				ProtocolVersionsHelper.BEFORE_1_13


### PR DESCRIPTION
This resolves the last of the remaining blocks listed in #898 

Namely oak_wood, spruce_wood, jungle_wood, birch_wood, acacia_wood, dark_oak_wood, stone_slab, brick_slab, stone_brick_slab, nether_brick_slab, quartz_slab, purpur_slab, nether_brick_fence and red_mushroom_block.

Also allows stripped wood blocks to be remapped, though not directly added here.