### PR TITLE
If PE user tries to connect with a too old client, give correct error message

### DIFF
--- a/src/protocolsupport/protocol/packet/handler/AbstractHandshakeListener.java
+++ b/src/protocolsupport/protocol/packet/handler/AbstractHandshakeListener.java
@@ -44,8 +44,20 @@ public abstract class AbstractHandshakeListener implements IPacketListener {
 				ConnectionImpl connection = ConnectionImpl.getFromChannel(networkManager.getChannel());
 				//version check
 				if (!connection.getVersion().isSupported()) {
-					disconnect(MessageFormat.format(ServerPlatform.get().getMiscUtils().getOutdatedServerMessage().replace("'", "''"), 
-						connection.getVersion().getProtocolType() == ProtocolType.PE ? ProtocolVersionsHelper.LATEST_PE.getName() : ServerPlatform.get().getMiscUtils().getVersionName()));
+					String message;
+					if (connection.getVersion().getProtocolType() == ProtocolType.PE) {
+						if (connection.getVersion().isBefore(ProtocolVersionsHelper.LATEST_PE)) {
+							message = MessageFormat.format(ServerPlatform.get().getMiscUtils().getOutdatedClientMessage().replace("'", "''"),
+								ProtocolVersionsHelper.LATEST_PE.getName());
+						} else {
+							message = MessageFormat.format(ServerPlatform.get().getMiscUtils().getOutdatedServerMessage().replace("'", "''"),
+								ProtocolVersionsHelper.LATEST_PE.getName());
+						}
+					} else {
+						message = MessageFormat.format(ServerPlatform.get().getMiscUtils().getOutdatedClientMessage().replace("'", "''"),
+							ServerPlatform.get().getMiscUtils().getVersionName());
+					}
+					disconnect(message);
 					break;
 				}
 				//ps handshake event


### PR DESCRIPTION
I tried connecting with PE client 1.6, and got the message "Your sever is outdated. Please use 1.7".  The proper message should have been that my *client* is too old, and should be upgraded to 1.7.

I thought I've fixed this before, but that code seems to have gotten rewritten and lost. I know this case is a bit odd in the PS case, since normally "your client is too old" is not even possible to happen with PS.