### PR TITLE
Refactor the MiddleBlocks to have a create() method, which is called by the constructor.

### DIFF
--- a/src/protocolsupport/protocol/packet/middle/serverbound/play/MiddleAnimation.java
+++ b/src/protocolsupport/protocol/packet/middle/serverbound/play/MiddleAnimation.java
@@ -19,9 +19,13 @@ public abstract class MiddleAnimation extends ServerBoundMiddlePacket {
 
 	@Override
 	public RecyclableCollection<ServerBoundPacketData> toNative() {
+		return RecyclableSingletonList.create(create(hand));
+	}
+
+	public static ServerBoundPacketData create(UsedHand hand) {
 		ServerBoundPacketData creator = ServerBoundPacketData.create(ServerBoundPacket.PLAY_ANIMATION);
 		MiscSerializer.writeVarIntEnum(creator, hand);
-		return RecyclableSingletonList.create(creator);
+		return creator;
 	}
 
 }

--- a/src/protocolsupport/protocol/packet/middle/serverbound/play/MiddleBlockDig.java
+++ b/src/protocolsupport/protocol/packet/middle/serverbound/play/MiddleBlockDig.java
@@ -23,11 +23,15 @@ public abstract class MiddleBlockDig extends ServerBoundMiddlePacket {
 
 	@Override
 	public RecyclableCollection<ServerBoundPacketData> toNative() {
+		return RecyclableSingletonList.create(create(status, position, face));
+	}
+
+	public static ServerBoundPacketData create(Action status, Position position, int face) {
 		ServerBoundPacketData creator = ServerBoundPacketData.create(ServerBoundPacket.PLAY_BLOCK_DIG);
 		MiscSerializer.writeVarIntEnum(creator, status);
 		PositionSerializer.writePosition(creator, position);
 		creator.writeByte(face);
-		return RecyclableSingletonList.create(creator);
+		return creator;
 	}
 
 	protected static enum Action {

--- a/src/protocolsupport/protocol/packet/middle/serverbound/play/MiddleBlockPlace.java
+++ b/src/protocolsupport/protocol/packet/middle/serverbound/play/MiddleBlockPlace.java
@@ -27,6 +27,10 @@ public abstract class MiddleBlockPlace extends ServerBoundMiddlePacket {
 
 	@Override
 	public RecyclableCollection<ServerBoundPacketData> toNative() {
+		return RecyclableSingletonList.create(create(position, face, hand, cX, cY, cZ));
+	}
+
+	public static ServerBoundPacketData create(Position position, int face, UsedHand hand, float cX, float cY, float cZ) {
 		if (face != -1) {
 			ServerBoundPacketData creator = ServerBoundPacketData.create(ServerBoundPacket.PLAY_USE_ITEM);
 			PositionSerializer.writePosition(creator, position);
@@ -35,11 +39,11 @@ public abstract class MiddleBlockPlace extends ServerBoundMiddlePacket {
 			creator.writeFloat(cX);
 			creator.writeFloat(cY);
 			creator.writeFloat(cZ);
-			return RecyclableSingletonList.create(creator);
+			return creator;
 		} else {
 			ServerBoundPacketData creator = ServerBoundPacketData.create(ServerBoundPacket.PLAY_BLOCK_PLACE);
 			MiscSerializer.writeVarIntEnum(creator, hand);
-			return RecyclableSingletonList.create(creator);
+			return creator;
 		}
 	}
 

--- a/src/protocolsupport/protocol/packet/middle/serverbound/play/MiddleChat.java
+++ b/src/protocolsupport/protocol/packet/middle/serverbound/play/MiddleChat.java
@@ -19,9 +19,13 @@ public abstract class MiddleChat extends ServerBoundMiddlePacket {
 
 	@Override
 	public RecyclableCollection<ServerBoundPacketData> toNative() {
+		return RecyclableSingletonList.create(create(message));
+	}
+
+	public static ServerBoundPacketData create(String message) {
 		ServerBoundPacketData creator = ServerBoundPacketData.create(ServerBoundPacket.PLAY_CHAT);
 		StringSerializer.writeString(creator, ProtocolVersionsHelper.LATEST_PC, message);
-		return RecyclableSingletonList.create(creator);
+		return creator;
 	}
 
 }

--- a/src/protocolsupport/protocol/packet/middle/serverbound/play/MiddleClientSettings.java
+++ b/src/protocolsupport/protocol/packet/middle/serverbound/play/MiddleClientSettings.java
@@ -29,6 +29,10 @@ public abstract class MiddleClientSettings extends ServerBoundMiddlePacket {
 	@Override
 	public RecyclableCollection<ServerBoundPacketData> toNative() {
 		cache.getAttributesCache().setLocale(locale);
+		return RecyclableSingletonList.create(create(locale, viewDist, chatMode, chatColors, skinFlags, mainHand));
+	}
+
+	public static ServerBoundPacketData create(String locale, int viewDist, ChatMode chatMode, boolean chatColors, int skinFlags, MainHand mainHand) {
 		ServerBoundPacketData creator = ServerBoundPacketData.create(ServerBoundPacket.PLAY_SETTINGS);
 		StringSerializer.writeString(creator, ProtocolVersionsHelper.LATEST_PC, locale);
 		creator.writeByte(viewDist);
@@ -36,7 +40,7 @@ public abstract class MiddleClientSettings extends ServerBoundMiddlePacket {
 		creator.writeBoolean(chatColors);
 		creator.writeByte(skinFlags);
 		MiscSerializer.writeVarIntEnum(creator, mainHand);
-		return RecyclableSingletonList.create(creator);
+		return creator;
 	}
 
 	protected static enum ChatMode {

--- a/src/protocolsupport/protocol/packet/middle/serverbound/play/MiddleCreativeSetSlot.java
+++ b/src/protocolsupport/protocol/packet/middle/serverbound/play/MiddleCreativeSetSlot.java
@@ -21,10 +21,14 @@ public abstract class MiddleCreativeSetSlot extends ServerBoundMiddlePacket {
 
 	@Override
 	public RecyclableCollection<ServerBoundPacketData> toNative() {
+		return RecyclableSingletonList.create(create(cache.getAttributesCache().getLocale(), slot, itemstack));
+	}
+
+	public static ServerBoundPacketData create(String locale, int slot, NetworkItemStack itemstack) {
 		ServerBoundPacketData creator = ServerBoundPacketData.create(ServerBoundPacket.PLAY_CREATIVE_SET_SLOT);
 		creator.writeShort(slot);
-		ItemStackSerializer.writeItemStack(creator, ProtocolVersionsHelper.LATEST_PC, cache.getAttributesCache().getLocale(), itemstack, false);
-		return RecyclableSingletonList.create(creator);
+		ItemStackSerializer.writeItemStack(creator, ProtocolVersionsHelper.LATEST_PC, locale, itemstack, false);
+		return creator;
 	}
 
 }

--- a/src/protocolsupport/protocol/packet/middle/serverbound/play/MiddleCustomPayload.java
+++ b/src/protocolsupport/protocol/packet/middle/serverbound/play/MiddleCustomPayload.java
@@ -10,7 +10,6 @@ import protocolsupport.protocol.utils.ProtocolVersionsHelper;
 import protocolsupport.utils.recyclable.RecyclableCollection;
 import protocolsupport.utils.recyclable.RecyclableSingletonList;
 
-
 public abstract class MiddleCustomPayload extends ServerBoundMiddlePacket {
 
 	public MiddleCustomPayload(ConnectionImpl connection) {
@@ -23,6 +22,12 @@ public abstract class MiddleCustomPayload extends ServerBoundMiddlePacket {
 	@Override
 	public RecyclableCollection<ServerBoundPacketData> toNative() {
 		return RecyclableSingletonList.create(create(tag, data));
+	}
+
+	public static ServerBoundPacketData create(String tag) {
+		ServerBoundPacketData serializer = ServerBoundPacketData.create(ServerBoundPacket.PLAY_CUSTOM_PAYLOAD);
+		StringSerializer.writeString(serializer, ProtocolVersionsHelper.LATEST_PC, tag);
+		return serializer;
 	}
 
 	public static ServerBoundPacketData create(String tag, byte[] data) {

--- a/src/protocolsupport/protocol/packet/middle/serverbound/play/MiddleEntityAction.java
+++ b/src/protocolsupport/protocol/packet/middle/serverbound/play/MiddleEntityAction.java
@@ -22,11 +22,16 @@ public abstract class MiddleEntityAction extends ServerBoundMiddlePacket {
 
 	@Override
 	public RecyclableCollection<ServerBoundPacketData> toNative() {
+		ServerBoundPacketData creator = MiddleEntityAction.create(entityId, action, jumpBoost);
+		return RecyclableSingletonList.create(creator);
+	}
+
+	public static ServerBoundPacketData create(int entityId, Action action, int jumpBoost) {
 		ServerBoundPacketData creator = ServerBoundPacketData.create(ServerBoundPacket.PLAY_ENTITY_ACTION);
 		VarNumberSerializer.writeVarInt(creator, entityId);
 		MiscSerializer.writeVarIntEnum(creator, action);
 		VarNumberSerializer.writeVarInt(creator, jumpBoost);
-		return RecyclableSingletonList.create(creator);
+		return creator;
 	}
 
 	protected static enum Action {

--- a/src/protocolsupport/protocol/packet/middle/serverbound/play/MiddleHeldSlot.java
+++ b/src/protocolsupport/protocol/packet/middle/serverbound/play/MiddleHeldSlot.java
@@ -17,9 +17,13 @@ public abstract class MiddleHeldSlot extends ServerBoundMiddlePacket {
 
 	@Override
 	public RecyclableCollection<ServerBoundPacketData> toNative() {
+		return RecyclableSingletonList.create(create(slot));
+	}
+
+	public static ServerBoundPacketData create(int slot) {
 		ServerBoundPacketData creator = ServerBoundPacketData.create(ServerBoundPacket.PLAY_HELD_SLOT);
 		creator.writeShort(slot);
-		return RecyclableSingletonList.create(creator);
+		return creator;
 	}
 
 }

--- a/src/protocolsupport/protocol/packet/middle/serverbound/play/MiddleInventoryClick.java
+++ b/src/protocolsupport/protocol/packet/middle/serverbound/play/MiddleInventoryClick.java
@@ -25,14 +25,18 @@ public abstract class MiddleInventoryClick extends ServerBoundMiddlePacket {
 
 	@Override
 	public RecyclableCollection<ServerBoundPacketData> toNative() {
+		return RecyclableSingletonList.create(create(cache.getAttributesCache().getLocale(), windowId, slot, button, actionNumber, mode, itemstack));
+	}
+
+	public static ServerBoundPacketData create(String locale, int windowId, int slot, int button, int actionNumber, int mode, NetworkItemStack itemstack) {
 		ServerBoundPacketData creator = ServerBoundPacketData.create(ServerBoundPacket.PLAY_WINDOW_CLICK);
 		creator.writeByte(windowId);
 		creator.writeShort(slot);
 		creator.writeByte(button);
 		creator.writeShort(actionNumber);
 		creator.writeByte(mode);
-		ItemStackSerializer.writeItemStack(creator, ProtocolVersionsHelper.LATEST_PC, cache.getAttributesCache().getLocale(), itemstack, false);
-		return RecyclableSingletonList.create(creator);
+		ItemStackSerializer.writeItemStack(creator, ProtocolVersionsHelper.LATEST_PC, locale, itemstack, false);
+		return creator;
 	}
 
 }

--- a/src/protocolsupport/protocol/packet/middle/serverbound/play/MiddleInventoryClose.java
+++ b/src/protocolsupport/protocol/packet/middle/serverbound/play/MiddleInventoryClose.java
@@ -18,9 +18,13 @@ public abstract class MiddleInventoryClose extends ServerBoundMiddlePacket {
 	@Override
 	public RecyclableCollection<ServerBoundPacketData> toNative() {
 		cache.getWindowCache().closeWindow();
+		return RecyclableSingletonList.create(create(windowId));
+	}
+
+	public static ServerBoundPacketData create(int windowId) {
 		ServerBoundPacketData creator = ServerBoundPacketData.create(ServerBoundPacket.PLAY_WINDOW_CLOSE);
 		creator.writeByte(windowId);
-		return RecyclableSingletonList.create(creator);
+		return creator;
 	}
 
 }

--- a/src/protocolsupport/protocol/packet/middle/serverbound/play/MiddleInventoryEnchant.java
+++ b/src/protocolsupport/protocol/packet/middle/serverbound/play/MiddleInventoryEnchant.java
@@ -18,10 +18,14 @@ public abstract class MiddleInventoryEnchant extends ServerBoundMiddlePacket {
 
 	@Override
 	public RecyclableCollection<ServerBoundPacketData> toNative() {
+		return RecyclableSingletonList.create(create(windowId, enchantment));
+	}
+
+	public static ServerBoundPacketData create(int windowId, int enchantment) {
 		ServerBoundPacketData creator = ServerBoundPacketData.create(ServerBoundPacket.PLAY_ENCHANT_SELECT);
 		creator.writeByte(windowId);
 		creator.writeByte(enchantment);
-		return RecyclableSingletonList.create(creator);
+		return creator;
 	}
 
 }

--- a/src/protocolsupport/protocol/packet/middle/serverbound/play/MiddleInventoryTransaction.java
+++ b/src/protocolsupport/protocol/packet/middle/serverbound/play/MiddleInventoryTransaction.java
@@ -19,11 +19,15 @@ public abstract class MiddleInventoryTransaction extends ServerBoundMiddlePacket
 
 	@Override
 	public RecyclableCollection<ServerBoundPacketData> toNative() {
+		return RecyclableSingletonList.create(create(windowId, actionNumber, accepted));
+	}
+
+	public static ServerBoundPacketData create(int windowId, int actionNumber, boolean accepted) {
 		ServerBoundPacketData creator = ServerBoundPacketData.create(ServerBoundPacket.PLAY_WINDOW_TRANSACTION);
 		creator.writeByte(windowId);
 		creator.writeShort(actionNumber);
 		creator.writeBoolean(accepted);
-		return RecyclableSingletonList.create(creator);
+		return creator;
 	}
 
 }

--- a/src/protocolsupport/protocol/packet/middle/serverbound/play/MiddleMoveVehicle.java
+++ b/src/protocolsupport/protocol/packet/middle/serverbound/play/MiddleMoveVehicle.java
@@ -21,13 +21,17 @@ public abstract class MiddleMoveVehicle extends ServerBoundMiddlePacket {
 
 	@Override
 	public RecyclableCollection<ServerBoundPacketData> toNative() {
+		return RecyclableSingletonList.create(create(x, y, z, yaw, pitch));
+	}
+
+	public static ServerBoundPacketData create(double x, double y, double z, float yaw, float pitch) {
 		ServerBoundPacketData creator = ServerBoundPacketData.create(ServerBoundPacket.PLAY_MOVE_VEHICLE);
 		creator.writeDouble(x);
 		creator.writeDouble(y);
 		creator.writeDouble(z);
 		creator.writeFloat(yaw);
 		creator.writeFloat(pitch);
-		return RecyclableSingletonList.create(creator);
+		return creator;
 	}
 
 }

--- a/src/protocolsupport/protocol/packet/middle/serverbound/play/MiddleSelectTrade.java
+++ b/src/protocolsupport/protocol/packet/middle/serverbound/play/MiddleSelectTrade.java
@@ -18,9 +18,13 @@ public abstract class MiddleSelectTrade extends ServerBoundMiddlePacket {
 
 	@Override
 	public RecyclableCollection<ServerBoundPacketData> toNative() {
+		return RecyclableSingletonList.create(create(slot));
+	}
+
+	public static ServerBoundPacketData create(int slot) {
 		ServerBoundPacketData creator = ServerBoundPacketData.create(ServerBoundPacket.PLAY_SELECT_TRADE);
 		VarNumberSerializer.writeVarInt(creator, slot);
-		return RecyclableSingletonList.create(creator);
+		return creator;
 	}
 
 }

--- a/src/protocolsupport/protocol/packet/middle/serverbound/play/MiddleSteerBoat.java
+++ b/src/protocolsupport/protocol/packet/middle/serverbound/play/MiddleSteerBoat.java
@@ -18,10 +18,14 @@ public abstract class MiddleSteerBoat extends ServerBoundMiddlePacket {
 
 	@Override
 	public RecyclableCollection<ServerBoundPacketData> toNative() {
+		return RecyclableSingletonList.create(create(rightPaddleTurning, leftPaddleTurning));
+	}
+
+	public static ServerBoundPacketData create(boolean rightPaddleTurning, boolean leftPaddleTurning) {
 		ServerBoundPacketData creator = ServerBoundPacketData.create(ServerBoundPacket.PLAY_STEER_BOAT);
 		creator.writeBoolean(rightPaddleTurning);
 		creator.writeBoolean(leftPaddleTurning);
-		return RecyclableSingletonList.create(creator);
+		return creator;
 	}
 
 }

--- a/src/protocolsupport/protocol/packet/middle/serverbound/play/MiddleSteerVehicle.java
+++ b/src/protocolsupport/protocol/packet/middle/serverbound/play/MiddleSteerVehicle.java
@@ -19,11 +19,15 @@ public abstract class MiddleSteerVehicle extends ServerBoundMiddlePacket {
 
 	@Override
 	public RecyclableCollection<ServerBoundPacketData> toNative() {
+		return RecyclableSingletonList.create(create(sideForce, forwardForce, flags));
+	}
+
+	public static ServerBoundPacketData create(float sideForce, float forwardForce, int flags) {
 		ServerBoundPacketData creator = ServerBoundPacketData.create(ServerBoundPacket.PLAY_STEER_VEHICLE);
 		creator.writeFloat(sideForce);
 		creator.writeFloat(forwardForce);
 		creator.writeByte(flags);
-		return RecyclableSingletonList.create(creator);
+		return creator;
 	}
 
 }

--- a/src/protocolsupport/protocol/packet/middle/serverbound/play/MiddleUpdateSign.java
+++ b/src/protocolsupport/protocol/packet/middle/serverbound/play/MiddleUpdateSign.java
@@ -22,12 +22,16 @@ public abstract class MiddleUpdateSign extends ServerBoundMiddlePacket {
 
 	@Override
 	public RecyclableCollection<ServerBoundPacketData> toNative() {
+		return RecyclableSingletonList.create(create(position, lines));
+	}
+
+	public static ServerBoundPacketData create(Position position, String[] lines) {
 		ServerBoundPacketData creator = ServerBoundPacketData.create(ServerBoundPacket.PLAY_UPDATE_SIGN);
 		PositionSerializer.writePosition(creator, position);
 		for (int i = 0; i < lines.length; i++) {
 			StringSerializer.writeString(creator, ProtocolVersionsHelper.LATEST_PC, lines[i]);
 		}
-		return RecyclableSingletonList.create(creator);
+		return creator;
 	}
 
 }

--- a/src/protocolsupport/protocol/packet/middle/serverbound/play/MiddleUseEntity.java
+++ b/src/protocolsupport/protocol/packet/middle/serverbound/play/MiddleUseEntity.java
@@ -26,6 +26,10 @@ public abstract class MiddleUseEntity extends ServerBoundMiddlePacket {
 
 	@Override
 	public RecyclableCollection<ServerBoundPacketData> toNative() {
+		return RecyclableSingletonList.create(create(entityId, action, interactedAt, hand));
+	}
+
+	public static ServerBoundPacketData create(int entityId, Action action, Vector interactedAt, UsedHand hand) {
 		ServerBoundPacketData creator = ServerBoundPacketData.create(ServerBoundPacket.PLAY_USE_ENTITY);
 		VarNumberSerializer.writeVarInt(creator, entityId);
 		MiscSerializer.writeVarIntEnum(creator, action);
@@ -45,7 +49,7 @@ public abstract class MiddleUseEntity extends ServerBoundMiddlePacket {
 				break;
 			}
 		}
-		return RecyclableSingletonList.create(creator);
+		return creator;
 	}
 
 	protected enum Action {


### PR DESCRIPTION
I'm looking at the diff between master and mcpenew, and trying to minimize it, from both sides.

This is a simple refactoring that breaks out the actual work of the constructor into a create() method, that can be independently called, for all middle blocks, which is needed by PSPE.