### PR TITLE
Create PE-specific version of writeUUID

### DIFF
--- a/src/protocolsupport/listeners/InternalPluginMessageRequest.java
+++ b/src/protocolsupport/listeners/InternalPluginMessageRequest.java
@@ -61,7 +61,7 @@ public class InternalPluginMessageRequest implements PluginMessageListener {
 	public static ServerBoundPacketData newPluginMessageRequest(PluginMessageData data) {
 		ByteBuf buf = Unpooled.buffer();
 		try {
-			MiscSerializer.writeUUID(buf, ProtocolVersionsHelper.LATEST_PC, uuid);
+			MiscSerializer.writeUUID(buf, uuid);
 			StringSerializer.writeString(buf, ProtocolVersionsHelper.LATEST_PC, (data.getClass().getSimpleName()));
 			data.write(buf);
 			return protocolsupport.protocol.packet.middle.serverbound.play.MiddleCustomPayload.create(TAG, buf);
@@ -73,7 +73,7 @@ public class InternalPluginMessageRequest implements PluginMessageListener {
 	public static void receivePluginMessageRequest(Connection connection, PluginMessageData data) {
 		ByteBuf buf = Unpooled.buffer();
 		try {
-			MiscSerializer.writeUUID(buf, ProtocolVersionsHelper.LATEST_PC, uuid);
+			MiscSerializer.writeUUID(buf, uuid);
 			StringSerializer.writeString(buf, ProtocolVersionsHelper.LATEST_PC, (data.getClass().getSimpleName()));
 			data.write(buf);
 			connection.receivePacket(ServerPlatform.get().getPacketFactory().createInboundPluginMessagePacket(TAG, MiscSerializer.readAllBytes(buf)));

--- a/src/protocolsupport/protocol/packet/middle/serverbound/play/MiddleSpecate.java
+++ b/src/protocolsupport/protocol/packet/middle/serverbound/play/MiddleSpecate.java
@@ -2,6 +2,7 @@ package protocolsupport.protocol.packet.middle.serverbound.play;
 
 import java.util.UUID;
 
+import protocolsupport.api.ProtocolType;
 import protocolsupport.protocol.ConnectionImpl;
 import protocolsupport.protocol.packet.ServerBoundPacket;
 import protocolsupport.protocol.packet.middle.ServerBoundMiddlePacket;
@@ -21,7 +22,12 @@ public abstract class MiddleSpecate extends ServerBoundMiddlePacket {
 	@Override
 	public RecyclableCollection<ServerBoundPacketData> toNative() {
 		ServerBoundPacketData creator = ServerBoundPacketData.create(ServerBoundPacket.PLAY_SPECTATE);
-		MiscSerializer.writeUUID(creator, connection.getVersion(), entityUUID);
+		// FIXME: Maybe we can assume PC here..? Only implemented in v_8_9r1_9r2_10_11_12r1_12r2_13
+		if (connection.getVersion().getProtocolType() == ProtocolType.PE) {
+			MiscSerializer.writePEUUID(creator, entityUUID);
+		} else {
+			MiscSerializer.writeUUID(creator, entityUUID);
+		}
 		return RecyclableSingletonList.create(creator);
 	}
 

--- a/src/protocolsupport/protocol/packet/middle/serverbound/play/MiddleSpecate.java
+++ b/src/protocolsupport/protocol/packet/middle/serverbound/play/MiddleSpecate.java
@@ -22,12 +22,7 @@ public abstract class MiddleSpecate extends ServerBoundMiddlePacket {
 	@Override
 	public RecyclableCollection<ServerBoundPacketData> toNative() {
 		ServerBoundPacketData creator = ServerBoundPacketData.create(ServerBoundPacket.PLAY_SPECTATE);
-		// FIXME: Maybe we can assume PC here..? Only implemented in v_8_9r1_9r2_10_11_12r1_12r2_13
-		if (connection.getVersion().getProtocolType() == ProtocolType.PE) {
-			MiscSerializer.writePEUUID(creator, entityUUID);
-		} else {
-			MiscSerializer.writeUUID(creator, entityUUID);
-		}
+		MiscSerializer.writeUUID(creator, entityUUID);
 		return RecyclableSingletonList.create(creator);
 	}
 

--- a/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_11_12r1_12r2/SpawnLiving.java
+++ b/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_11_12r1_12r2/SpawnLiving.java
@@ -23,7 +23,7 @@ public class SpawnLiving extends MiddleSpawnLiving {
 		ProtocolVersion version = connection.getVersion();
 		ClientBoundPacketData serializer = ClientBoundPacketData.create(ClientBoundPacket.PLAY_SPAWN_LIVING_ID);
 		VarNumberSerializer.writeVarInt(serializer, entity.getId());
-		MiscSerializer.writeUUID(serializer, connection.getVersion(), entity.getUUID());
+		MiscSerializer.writeUUID(serializer, entity.getUUID());
 		VarNumberSerializer.writeVarInt(serializer, LegacyEntityId.getLegacyId(entityRemapper.getRemappedEntityType()));
 		serializer.writeDouble(x);
 		serializer.writeDouble(y);

--- a/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_13/SpawnLiving.java
+++ b/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_13/SpawnLiving.java
@@ -22,7 +22,7 @@ public class SpawnLiving extends MiddleSpawnLiving {
 		ProtocolVersion version = connection.getVersion();
 		ClientBoundPacketData serializer = ClientBoundPacketData.create(ClientBoundPacket.PLAY_SPAWN_LIVING_ID);
 		VarNumberSerializer.writeVarInt(serializer, entity.getId());
-		MiscSerializer.writeUUID(serializer, version, entity.getUUID());
+		MiscSerializer.writeUUID(serializer, entity.getUUID());
 		VarNumberSerializer.writeVarInt(serializer, entityRemapper.getRemappedEntityType().getNetworkTypeId());
 		serializer.writeDouble(x);
 		serializer.writeDouble(y);

--- a/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_13/SpawnPainting.java
+++ b/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_13/SpawnPainting.java
@@ -20,7 +20,7 @@ public class SpawnPainting extends MiddleSpawnPainting {
 	public RecyclableCollection<ClientBoundPacketData> toData() {
 		ClientBoundPacketData serializer = ClientBoundPacketData.create(ClientBoundPacket.PLAY_SPAWN_PAINTING_ID);
 		VarNumberSerializer.writeVarInt(serializer, entity.getId());
-		MiscSerializer.writeUUID(serializer, connection.getVersion(), entity.getUUID());
+		MiscSerializer.writeUUID(serializer, entity.getUUID());
 		VarNumberSerializer.writeVarInt(serializer, type);
 		PositionSerializer.writePosition(serializer, position);
 		serializer.writeByte(direction);

--- a/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_6_7/EntitySetAttributes.java
+++ b/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_6_7/EntitySetAttributes.java
@@ -39,7 +39,7 @@ public class EntitySetAttributes extends MiddleEntitySetAttributes {
 			if (version != ProtocolVersion.MINECRAFT_1_6_1) {
 				serializer.writeShort(attribute.modifiers.length);
 				for (Modifier modifier : attribute.modifiers) {
-					MiscSerializer.writeUUID(serializer, connection.getVersion(), modifier.uuid);
+					MiscSerializer.writeUUID(serializer, modifier.uuid);
 					serializer.writeDouble(modifier.amount);
 					serializer.writeByte(modifier.operation);
 				}

--- a/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_8/SpawnNamed.java
+++ b/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_8/SpawnNamed.java
@@ -22,7 +22,7 @@ public class SpawnNamed extends MiddleSpawnNamed {
 		ProtocolVersion version = connection.getVersion();
 		ClientBoundPacketData serializer = ClientBoundPacketData.create(ClientBoundPacket.PLAY_SPAWN_NAMED_ID);
 		VarNumberSerializer.writeVarInt(serializer, entity.getId());
-		MiscSerializer.writeUUID(serializer, connection.getVersion(), entity.getUUID());
+		MiscSerializer.writeUUID(serializer, entity.getUUID());
 		serializer.writeInt((int) (x * 32));
 		serializer.writeInt((int) (y * 32));
 		serializer.writeInt((int) (z * 32));

--- a/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_8_9r1_9r2_10_11_12r1_12r2_13/EntitySetAttributes.java
+++ b/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_8_9r1_9r2_10_11_12r1_12r2_13/EntitySetAttributes.java
@@ -39,7 +39,7 @@ public class EntitySetAttributes extends MiddleEntitySetAttributes {
 			serializer.writeDouble(attribute.value);
 			VarNumberSerializer.writeVarInt(serializer, attribute.modifiers.length);
 			for (Modifier modifier : attribute.modifiers) {
-				MiscSerializer.writeUUID(serializer, version, modifier.uuid);
+				MiscSerializer.writeUUID(serializer, modifier.uuid);
 				serializer.writeDouble(modifier.amount);
 				serializer.writeByte(modifier.operation);
 			}

--- a/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_8_9r1_9r2_10_11_12r1_12r2_13/PlayerListSetEntry.java
+++ b/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_8_9r1_9r2_10_11_12r1_12r2_13/PlayerListSetEntry.java
@@ -31,7 +31,7 @@ public class PlayerListSetEntry extends MiddlePlayerListSetEntry {
 		VarNumberSerializer.writeVarInt(serializer, action.ordinal());
 		VarNumberSerializer.writeVarInt(serializer, infos.size());
 		for (Entry<UUID, Any<PlayerListEntry, PlayerListEntry>> entry : infos.entrySet()) {
-			MiscSerializer.writeUUID(serializer, version, entry.getKey());
+			MiscSerializer.writeUUID(serializer, entry.getKey());
 			PlayerListEntry currentEntry = entry.getValue().getObj2();
 			switch (action) {
 				case ADD: {

--- a/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_9r1_9r2_10/SpawnLiving.java
+++ b/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_9r1_9r2_10/SpawnLiving.java
@@ -23,7 +23,7 @@ public class SpawnLiving extends MiddleSpawnLiving {
 		ProtocolVersion version = connection.getVersion();
 		ClientBoundPacketData serializer = ClientBoundPacketData.create(ClientBoundPacket.PLAY_SPAWN_LIVING_ID);
 		VarNumberSerializer.writeVarInt(serializer, entity.getId());
-		MiscSerializer.writeUUID(serializer, connection.getVersion(), entity.getUUID());
+		MiscSerializer.writeUUID(serializer, entity.getUUID());
 		serializer.writeByte(LegacyEntityId.getLegacyId(entityRemapper.getRemappedEntityType()));
 		serializer.writeDouble(x);
 		serializer.writeDouble(y);

--- a/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_9r1_9r2_10_11_12r1_12r2/SpawnPainting.java
+++ b/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_9r1_9r2_10_11_12r1_12r2/SpawnPainting.java
@@ -22,7 +22,7 @@ public class SpawnPainting extends MiddleSpawnPainting {
 	public RecyclableCollection<ClientBoundPacketData> toData() {
 		ClientBoundPacketData serializer = ClientBoundPacketData.create(ClientBoundPacket.PLAY_SPAWN_PAINTING_ID);
 		VarNumberSerializer.writeVarInt(serializer, entity.getId());
-		MiscSerializer.writeUUID(serializer, connection.getVersion(), entity.getUUID());
+		MiscSerializer.writeUUID(serializer, entity.getUUID());
 		StringSerializer.writeString(serializer, connection.getVersion(), LegacyPainting.getName(type));
 		PositionSerializer.writePosition(serializer, position);
 		serializer.writeByte(direction);

--- a/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_9r1_9r2_10_11_12r1_12r2_13/BossBar.java
+++ b/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_9r1_9r2_10_11_12r1_12r2_13/BossBar.java
@@ -23,7 +23,7 @@ public class BossBar extends MiddleBossBar {
 	public RecyclableCollection<ClientBoundPacketData> toData() {
 		ProtocolVersion version = connection.getVersion();
 		ClientBoundPacketData serializer = ClientBoundPacketData.create(ClientBoundPacket.PLAY_BOSS_BAR_ID);
-		MiscSerializer.writeUUID(serializer, version, uuid);
+		MiscSerializer.writeUUID(serializer, uuid);
 		MiscSerializer.writeVarIntEnum(serializer, action);
 		switch (action) {
 			case ADD: {

--- a/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_9r1_9r2_10_11_12r1_12r2_13/SpawnNamed.java
+++ b/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_9r1_9r2_10_11_12r1_12r2_13/SpawnNamed.java
@@ -22,7 +22,7 @@ public class SpawnNamed extends MiddleSpawnNamed {
 		ProtocolVersion version = connection.getVersion();
 		ClientBoundPacketData serializer = ClientBoundPacketData.create(ClientBoundPacket.PLAY_SPAWN_NAMED_ID);
 		VarNumberSerializer.writeVarInt(serializer, entity.getId());
-		MiscSerializer.writeUUID(serializer, version, entity.getUUID());
+		MiscSerializer.writeUUID(serializer, entity.getUUID());
 		serializer.writeDouble(x);
 		serializer.writeDouble(y);
 		serializer.writeDouble(z);

--- a/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_9r1_9r2_10_11_12r1_12r2_13/SpawnObject.java
+++ b/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_9r1_9r2_10_11_12r1_12r2_13/SpawnObject.java
@@ -22,7 +22,7 @@ public class SpawnObject extends MiddleSpawnObject {
 		objectdata = entityObjectDataRemappingTable.getRemap(type).applyAsInt(objectdata);
 		ClientBoundPacketData serializer = ClientBoundPacketData.create(ClientBoundPacket.PLAY_SPAWN_OBJECT_ID);
 		VarNumberSerializer.writeVarInt(serializer, entity.getId());
-		MiscSerializer.writeUUID(serializer, connection.getVersion(), entity.getUUID());
+		MiscSerializer.writeUUID(serializer, entity.getUUID());
 		serializer.writeByte(type.getNetworkTypeId());
 		serializer.writeDouble(x);
 		serializer.writeDouble(y);

--- a/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_pe/CraftingData.java
+++ b/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_pe/CraftingData.java
@@ -118,7 +118,7 @@ public class CraftingData extends MiddleDeclareRecipes {
 		}
 		VarNumberSerializer.writeVarInt(to, 1); // result item count (PC only supports one itemstack output, so hardcoded to 1)
 		ItemStackSerializer.writeItemStack(to, connection.getVersion(), locale, output, true);
-		MiscSerializer.writeUUID(to, connection.getVersion(), UUID.nameUUIDFromBytes(to.array()));
+		MiscSerializer.writePEUUID(to, UUID.nameUUIDFromBytes(to.array()));
 		recipesWritten++;
 	}
 
@@ -131,7 +131,7 @@ public class CraftingData extends MiddleDeclareRecipes {
 		}
 		VarNumberSerializer.writeVarInt(to, 1); // result item count (PC only supports one itemstack output, so hardcoded to 1)
 		ItemStackSerializer.writeItemStack(to, connection.getVersion(), locale, output, true);
-		MiscSerializer.writeUUID(to, connection.getVersion(), UUID.nameUUIDFromBytes(to.array()));
+		MiscSerializer.writePEUUID(to, UUID.nameUUIDFromBytes(to.array()));
 		recipesWritten++;
 	}
 

--- a/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_pe/PlayerListSetEntry.java
+++ b/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_pe/PlayerListSetEntry.java
@@ -59,7 +59,7 @@ public class PlayerListSetEntry extends MiddlePlayerListSetEntry {
 				for (Entry<UUID, Any<PlayerListEntry, PlayerListEntry>> entry : infos.entrySet()) {
 					UUID uuid = entry.getKey();
 					PlayerListEntry currentEntry = entry.getValue().getObj2();
-					MiscSerializer.writeUUID(serializer, version, uuid);
+					MiscSerializer.writePEUUID(serializer, uuid);
 					VarNumberSerializer.writeVarInt(serializer, 0); //entity id
 					StringSerializer.writeString(serializer, version, currentEntry.getCurrentName(attrscache.getLocale()));
 					Any<Boolean, String> skininfo = getSkinInfo(currentEntry.getProperties(true));
@@ -82,7 +82,7 @@ public class PlayerListSetEntry extends MiddlePlayerListSetEntry {
 				serializer.writeByte(1);
 				VarNumberSerializer.writeVarInt(serializer, infos.size());
 				for (Entry<UUID, Any<PlayerListEntry, PlayerListEntry>> entry : infos.entrySet()) {
-					MiscSerializer.writeUUID(serializer, version, entry.getKey());
+					MiscSerializer.writePEUUID(serializer, entry.getKey());
 				}
 				return RecyclableSingletonList.create(serializer);
 			}
@@ -126,7 +126,7 @@ public class PlayerListSetEntry extends MiddlePlayerListSetEntry {
 		@Override
 		public void accept(byte[] skindata) {
 			ByteBuf serializer = Unpooled.buffer();
-			MiscSerializer.writeUUID(serializer, connection.getVersion(), uuid);
+			MiscSerializer.writePEUUID(serializer, uuid);
 			writeSkinData(connection.getVersion(), serializer, true, isNormalModel, skindata);
 			connection.sendPacket(ServerPlatform.get().getPacketFactory().createOutboundPluginMessagePacket(InternalPluginMessageRequest.PESkinUpdateSuffix, serializer));
 		}

--- a/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_pe/SpawnNamed.java
+++ b/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_pe/SpawnNamed.java
@@ -25,7 +25,7 @@ public class SpawnNamed extends MiddleSpawnNamed {
 	public RecyclableCollection<ClientBoundPacketData> toData() {
 		ProtocolVersion version = connection.getVersion();
 		ClientBoundPacketData serializer = ClientBoundPacketData.create(PEPacketIDs.SPAWN_PLAYER);
-		MiscSerializer.writeUUID(serializer, connection.getVersion(), entity.getUUID());
+		MiscSerializer.writePEUUID(serializer, entity.getUUID());
 		PlayerListEntry entry = cache.getPlayerListCache().getEntry(entity.getUUID());
 		StringSerializer.writeString(serializer, version, entry != null ? entry.getCurrentName(cache.getAttributesCache().getLocale()) : "UNKNOWN");
 		VarNumberSerializer.writeSVarLong(serializer, entity.getId());

--- a/src/protocolsupport/protocol/serializer/MiscSerializer.java
+++ b/src/protocolsupport/protocol/serializer/MiscSerializer.java
@@ -33,18 +33,14 @@ public class MiscSerializer {
 		return new UUID(from.readLong(), from.readLong());
 	}
 
-	public static void writeUUID(ByteBuf to, ProtocolVersion version, UUID uuid) {
-		if (isUsingLittleEndian(version)) {
-			to.writeLongLE(uuid.getMostSignificantBits());
-			to.writeLongLE(uuid.getLeastSignificantBits());
-		} else {
-			to.writeLong(uuid.getMostSignificantBits());
-			to.writeLong(uuid.getLeastSignificantBits());
-		}
+	public static void writeUUID(ByteBuf to, UUID uuid) {
+		to.writeLong(uuid.getMostSignificantBits());
+		to.writeLong(uuid.getLeastSignificantBits());
 	}
 
-	private static boolean isUsingLittleEndian(ProtocolVersion version) {
-		return version.getProtocolType() == ProtocolType.PE;
+	public static void writePEUUID(ByteBuf to, UUID uuid) {
+		to.writeLongLE(uuid.getMostSignificantBits());
+		to.writeLongLE(uuid.getLeastSignificantBits());
 	}
 
 	public static byte[] readAllBytes(ByteBuf buf) {

--- a/src/protocolsupport/protocol/utils/datawatcher/objects/DataWatcherObjectOptionalUUID.java
+++ b/src/protocolsupport/protocol/utils/datawatcher/objects/DataWatcherObjectOptionalUUID.java
@@ -3,6 +3,7 @@ package protocolsupport.protocol.utils.datawatcher.objects;
 import java.util.UUID;
 
 import io.netty.buffer.ByteBuf;
+import protocolsupport.api.ProtocolType;
 import protocolsupport.api.ProtocolVersion;
 import protocolsupport.protocol.serializer.MiscSerializer;
 import protocolsupport.protocol.utils.datawatcher.ReadableDataWatcherObject;
@@ -20,7 +21,11 @@ public class DataWatcherObjectOptionalUUID extends ReadableDataWatcherObject<UUI
 	public void writeToStream(ByteBuf to, ProtocolVersion version, String locale) {
 		to.writeBoolean(value != null);
 		if (value != null) {
-			MiscSerializer.writeUUID(to, version, value);
+			if (version.getProtocolType() == ProtocolType.PE) {
+				MiscSerializer.writePEUUID(to, value);
+			} else {
+				MiscSerializer.writeUUID(to, value);
+			}
 		}
 	}
 


### PR DESCRIPTION
Create PE-specific version of writeUUID, to remove PE-specific changes to non-PE code.

This was prompted by Shev's response in https://github.com/ProtocolSupport/ProtocolSupport/pull/982.

I'd like some feedback on the fix in "MiddleSpecate.java" (also! Someone should fix the typo of that class name!). I assume I can remove the ProtocolType check and just assume PC, but I'd like to hear someone confirm it. (I'm not sure really why the middle classes seem to be doing middleimpl stuff...)

With this patch, the diff between master and mcpenew outside PE files will be reduced (but not zero).