### PR TITLE
Remap fixes.

### DIFF
--- a/resources/resources/pe/blockmapping.json
+++ b/resources/resources/pe/blockmapping.json
@@ -5779,6 +5779,10 @@
     "pename":"minecraft:shulker_box",
     "pedata":10
   },
+  "minecraft:blue_shulker_box[facing=up]":{
+    "pename":"minecraft:shulker_box",
+    "pedata":11
+  },
   "minecraft:brown_shulker_box[facing=up]":{
     "pename":"minecraft:shulker_box",
     "pedata":12
@@ -6633,19 +6637,19 @@
   },
   "minecraft:end_rod[facing=north]":{
     "pename":"minecraft:end_rod",
-    "pedata":2
+    "pedata":3
   },
   "minecraft:end_rod[facing=east]":{
     "pename":"minecraft:end_rod",
-    "pedata":5
+    "pedata":4
   },
   "minecraft:end_rod[facing=south]":{
     "pename":"minecraft:end_rod",
-    "pedata":3
+    "pedata":2
   },
   "minecraft:end_rod[facing=west]":{
     "pename":"minecraft:end_rod",
-    "pedata":4
+    "pedata":5
   },
   "minecraft:end_rod[facing=up]":{
     "pename":"minecraft:end_rod",
@@ -7238,5 +7242,125 @@
   "minecraft:horn_coral_wall_fan[facing=east,waterlogged=false]":{
   "pename":"minecraft:coral_fan_hang3",
   "pedata":4
+  },
+  "minecraft:skeleton_skull[rotation=0]":{
+    "pename":"minecraft:skull",
+    "pedata":1
+  },
+  "minecraft:skeleton_wall_skull[facing=north]":{
+    "pename":"minecraft:skull",
+    "pedata":2
+  },
+  "minecraft:skeleton_wall_skull[facing=south]":{
+    "pename":"minecraft:skull",
+    "pedata":3
+  },
+  "minecraft:skeleton_wall_skull[facing=west]":{
+    "pename":"minecraft:skull",
+    "pedata":4
+  },
+  "minecraft:skeleton_wall_skull[facing=east]":{
+    "pename":"minecraft:skull",
+    "pedata":5
+  },
+  "minecraft:wither_skeleton_skull[rotation=0]":{
+    "pename":"minecraft:skull",
+    "pedata":1
+  },
+  "minecraft:wither_skeleton_wall_skull[facing=north]":{
+    "pename":"minecraft:skull",
+    "pedata":2
+  },
+  "minecraft:wither_skeleton_wall_skull[facing=south]":{
+    "pename":"minecraft:skull",
+    "pedata":3
+  },
+  "minecraft:wither_skeleton_wall_skull[facing=west]":{
+    "pename":"minecraft:skull",
+    "pedata":4
+  },
+  "minecraft:wither_skeleton_wall_skull[facing=east]":{
+    "pename":"minecraft:skull",
+    "pedata":5
+  },
+  "minecraft:zombie_head[rotation=0]":{
+    "pename":"minecraft:skull",
+    "pedata":1
+  },
+  "minecraft:zombie_wall_head[facing=north]":{
+    "pename":"minecraft:skull",
+    "pedata":2
+  },
+  "minecraft:zombie_wall_head[facing=south]":{
+    "pename":"minecraft:skull",
+    "pedata":3
+  },
+  "minecraft:zombie_wall_head[facing=west]":{
+    "pename":"minecraft:skull",
+    "pedata":4
+  },
+  "minecraft:zombie_wall_head[facing=east]":{
+    "pename":"minecraft:skull",
+    "pedata":5
+  },
+  "minecraft:player_head[rotation=0]":{
+    "pename":"minecraft:skull",
+    "pedata":1
+  },
+  "minecraft:player_wall_head[facing=north]":{
+    "pename":"minecraft:skull",
+    "pedata":2
+  },
+  "minecraft:player_wall_head[facing=south]":{
+    "pename":"minecraft:skull",
+    "pedata":3
+  },
+  "minecraft:player_wall_head[facing=west]":{
+    "pename":"minecraft:skull",
+    "pedata":4
+  },
+  "minecraft:player_wall_head[facing=east]":{
+    "pename":"minecraft:skull",
+    "pedata":5
+  },
+  "minecraft:creeper_head[rotation=0]":{
+    "pename":"minecraft:skull",
+    "pedata":1
+  },
+  "minecraft:creeper_wall_head[facing=north]":{
+    "pename":"minecraft:skull",
+    "pedata":2
+  },
+  "minecraft:creeper_wall_head[facing=south]":{
+    "pename":"minecraft:skull",
+    "pedata":3
+  },
+  "minecraft:creeper_wall_head[facing=west]":{
+    "pename":"minecraft:skull",
+    "pedata":4
+  },
+  "minecraft:creeper_wall_head[facing=east]":{
+    "pename":"minecraft:skull",
+    "pedata":5
+  },
+  "minecraft:dragon_head[rotation=0]":{
+    "pename":"minecraft:skull",
+    "pedata":1
+  },
+  "minecraft:dragon_wall_head[facing=north]":{
+    "pename":"minecraft:skull",
+    "pedata":2
+  },
+  "minecraft:dragon_wall_head[facing=south]":{
+    "pename":"minecraft:skull",
+    "pedata":3
+  },
+  "minecraft:dragon_wall_head[facing=west]":{
+    "pename":"minecraft:skull",
+    "pedata":4
+  },
+  "minecraft:dragon_wall_head[facing=east]":{
+    "pename":"minecraft:skull",
+    "pedata":5
   }
 }

--- a/resources/resources/pe/itemmapping.json
+++ b/resources/resources/pe/itemmapping.json
@@ -930,7 +930,7 @@
     "pedata": 5
   },
   {
-    "itemkey": "carved_pumpkin",
+    "itemkey": "pumpkin",
     "peid": 86,
     "pedata": 0
   },

--- a/src/protocolsupport/protocol/typeremapper/block/LegacyBlockData.java
+++ b/src/protocolsupport/protocol/typeremapper/block/LegacyBlockData.java
@@ -232,7 +232,20 @@ public class LegacyBlockData {
 					Material.PLAYER_HEAD,
 					Material.ZOMBIE_HEAD
 				),
-				Material.SKELETON_SKULL.createBlockData(),
+				o -> o.getMaterial().createBlockData(),
+				ProtocolVersionsHelper.ALL_PE
+			);
+
+			this.<Directional>registerRemapEntryForAllStates(
+				Arrays.asList(
+					Material.SKELETON_WALL_SKULL,
+					Material.WITHER_SKELETON_WALL_SKULL,
+					Material.CREEPER_WALL_HEAD,
+					Material.DRAGON_WALL_HEAD,
+					Material.PLAYER_WALL_HEAD,
+					Material.ZOMBIE_WALL_HEAD
+				),
+				o -> cloneDirectional(o, (Directional) o.getMaterial().createBlockData()),
 				ProtocolVersionsHelper.ALL_PE
 			);
 
@@ -246,7 +259,7 @@ public class LegacyBlockData {
 					Material.ZOMBIE_WALL_HEAD
 				),
 				o -> cloneDirectional(o, (Directional) Material.SKELETON_WALL_SKULL.createBlockData()),
-				ProtocolVersionsHelper.BEFORE_1_13_AND_PE
+				ProtocolVersionsHelper.BEFORE_1_13
 			);
 			this.<MultipleFacing>registerRemapEntryForAllStates(
 				Arrays.asList(Material.COBBLESTONE_WALL, Material.MOSSY_COBBLESTONE_WALL),


### PR DESCRIPTION
Fix blue shulker box blocks, end rod orientations and pumpkin item remaps. Partial fix for mob heads (items work properly, blocks show up, but only as skeleton skulls).