### PR TITLE
More remap fixes

### DIFF
--- a/resources/resources/pe/blockmapping.json
+++ b/resources/resources/pe/blockmapping.json
@@ -447,6 +447,10 @@
     "pename":"minecraft:sandstone",
     "pedata":2
   },
+  "minecraft:smooth_sandstone":{
+    "pename":"minecraft:sandstone",
+    "pedata":3
+  },
   "minecraft:note_block[instrument=harp,note=0,powered=false]":{
     "pename":"minecraft:noteblock",
     "pedata":0
@@ -4207,9 +4211,13 @@
     "pename":"minecraft:quartz_block",
     "pedata":1
   },
-  "minecraft:quartz_pillar[axis=x]":{
+  "minecraft:smooth_quartz":{
     "pename":"minecraft:quartz_block",
     "pedata":3
+  },
+  "minecraft:quartz_pillar[axis=x]":{
+    "pename":"minecraft:quartz_block",
+    "pedata":6
   },
   "minecraft:quartz_pillar[axis=y]":{
     "pename":"minecraft:quartz_block",
@@ -4217,7 +4225,7 @@
   },
   "minecraft:quartz_pillar[axis=z]":{
     "pename":"minecraft:quartz_block",
-    "pedata":4
+    "pedata":10
   },
   "minecraft:quartz_stairs[facing=north,half=top,shape=straight,waterlogged=false]":{
     "pename":"minecraft:quartz_stairs",
@@ -4755,6 +4763,10 @@
     "pename":"minecraft:red_sandstone",
     "pedata":2
   },
+  "minecraft:smooth_red_sandstone":{
+    "pename":"minecraft:red_sandstone",
+    "pedata":3
+  },
   "minecraft:red_sandstone_stairs[facing=north,half=top,shape=straight,waterlogged=false]":{
     "pename":"minecraft:red_sandstone_stairs",
     "pedata":7
@@ -5016,20 +5028,8 @@
     "pedata":3
   },
   "minecraft:smooth_stone":{
-    "pename":"minecraft:double_stone_slab",
-    "pedata":8
-  },
-  "minecraft:smooth_sandstone":{
-    "pename":"minecraft:double_stone_slab",
-    "pedata":9
-  },
-  "minecraft:smooth_quartz":{
-    "pename":"minecraft:double_stone_slab",
-    "pedata":15
-  },
-  "minecraft:smooth_red_sandstone":{
-    "pename":"minecraft:double_stone_slab2",
-    "pedata":8
+    "pename":"minecraft:smooth_stone",
+    "pedata":0
   },
   "minecraft:spruce_fence_gate[facing=north,in_wall=false,open=true,powered=true]":{
     "pename":"minecraft:spruce_fence_gate",

--- a/src/protocolsupport/protocol/typeremapper/pe/PEDataValues.java
+++ b/src/protocolsupport/protocol/typeremapper/pe/PEDataValues.java
@@ -91,7 +91,7 @@ public class PEDataValues {
 		registerEntity(NetworkEntityType.SILVERFISH, 39, "minecraft:silverfish");
 		registerEntity(NetworkEntityType.ENDERMITE, 55, "minecraft:endermite");
 		registerEntity(NetworkEntityType.ENDER_DRAGON, 53, "minecraft:ender_dragon");
-		//registerEntity(NetworkEntityType.SNOWMAN, 21, null);
+		registerEntity(NetworkEntityType.SNOWMAN, 21, "minecraft:snow_golem");
 		registerEntity(NetworkEntityType.ZOMBIE, 32, "minecraft:zombie");
 		registerEntity(NetworkEntityType.ZOMBIE_VILLAGER, 44, "minecraft:zombie_villager");
 		registerEntity(NetworkEntityType.HUSK, 47, "minecraft:husk");
@@ -130,8 +130,8 @@ public class PEDataValues {
 		registerEntity(NetworkEntityType.TNT, null, "minecraft:tnt");
 		registerEntity(NetworkEntityType.SNOWBALL, null, "minecraft:snowball");
 		registerEntity(NetworkEntityType.EGG, null, "minecraft:egg");
-		registerEntity(NetworkEntityType.FIREBALL, null, "minecraft:small_fireball");
-		//registerEntity(NetworkEntityType.FIRECHARGE, null, null);
+		registerEntity(NetworkEntityType.FIREBALL, 85, "minecraft:fireball");
+		registerEntity(NetworkEntityType.FIRECHARGE, 64, "minecraft:small_fireball");
 		registerEntity(NetworkEntityType.ENDERPEARL, null, "minecraft:ender_pearl");
 		registerEntity(NetworkEntityType.WITHER_SKULL, null, "minecraft:wither_skull");
 		registerEntity(NetworkEntityType.FALLING_OBJECT, null, "minecraft:falling_block");
@@ -164,7 +164,6 @@ public class PEDataValues {
 		//registerEntity(NetworkEntityType.NPC, null, "minecraft:npc");
 		//registerEntity(NetworkEntityType.PANDA, null, "minecraft:panda");
 		//registerEntity(NetworkEntityType.BALLOON, null, "minecraft:balloon");
-		//registerEntity(NetworkEntityType.SNOW_GOLEM, null, "minecraft:snow_golem");
 		//registerEntity(NetworkEntityType.WITHER_SKULL_DANGEROUS, null, "minecraft:wither_skull_dangerous");
 		//registerEntity(NetworkEntityType.LIGHTNING_BOLT, null, "minecraft:lightning_bolt");
 		//registerEntity(NetworkEntityType.LINGERING_POTION, null, "minecraft:lingering_potion");


### PR DESCRIPTION
More remap fixes:
Fix smooth quartz,smooth [red] sandstone and smooth stone blocks.
Fix squartz pillar blocks.
Fix snow golem, ghast fireball and blaze firecharge entity mappings.