### PR TITLE
Fix colliding servers

### DIFF
--- a/src/protocolsupport/zplatform/impl/pe/PEProxyServerInfoHandler.java
+++ b/src/protocolsupport/zplatform/impl/pe/PEProxyServerInfoHandler.java
@@ -1,6 +1,7 @@
 package protocolsupport.zplatform.impl.pe;
 
 import java.text.MessageFormat;
+import java.util.Random;
 import java.util.concurrent.Executor;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -30,6 +31,7 @@ public class PEProxyServerInfoHandler implements PingHandler {
 
 	private static final int statusThreads = JavaSystemProperty.getValue("pestatusthreads", 2, Integer::parseInt);
 	private static final int statusThreadKeepAlive = JavaSystemProperty.getValue("pestatusthreadskeepalive", 60, Integer::parseInt);
+	private static final int randomId = new Random().nextInt();
 
 	static {
 		ProtocolSupport.logInfo(MessageFormat.format("PE status threads max count: {0}, keep alive time: {1}", statusThreads, statusThreadKeepAlive));
@@ -64,7 +66,7 @@ public class PEProxyServerInfoHandler implements PingHandler {
 				String.valueOf(ping.getProtocolData().getVersion()), ProtocolVersionsHelper.LATEST_PE.getName().replaceFirst("PE-", ""),
 				String.valueOf(ping.getPlayers().getOnline()),
 				String.valueOf(ping.getPlayers().getMax()),
-				"1337", //TODO: find out how it is used, apprently that is some sort of id
+				String.valueOf(randomId), // Needs to be unique per server (on a LAN?)
 				"ProtocolSupportPE",
 				"Survival"
 			);

--- a/src/protocolsupport/zplatform/impl/pe/PEProxyServerInfoHandler.java
+++ b/src/protocolsupport/zplatform/impl/pe/PEProxyServerInfoHandler.java
@@ -1,9 +1,9 @@
 package protocolsupport.zplatform.impl.pe;
 
 import java.text.MessageFormat;
-import java.util.Random;
 import java.util.concurrent.Executor;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
@@ -31,7 +31,7 @@ public class PEProxyServerInfoHandler implements PingHandler {
 
 	private static final int statusThreads = JavaSystemProperty.getValue("pestatusthreads", 2, Integer::parseInt);
 	private static final int statusThreadKeepAlive = JavaSystemProperty.getValue("pestatusthreadskeepalive", 60, Integer::parseInt);
-	private static final int randomId = new Random().nextInt();
+	private static final String randomId = String.valueOf(ThreadLocalRandom.current().nextInt());
 
 	static {
 		ProtocolSupport.logInfo(MessageFormat.format("PE status threads max count: {0}, keep alive time: {1}", statusThreads, statusThreadKeepAlive));
@@ -66,7 +66,7 @@ public class PEProxyServerInfoHandler implements PingHandler {
 				String.valueOf(ping.getProtocolData().getVersion()), ProtocolVersionsHelper.LATEST_PE.getName().replaceFirst("PE-", ""),
 				String.valueOf(ping.getPlayers().getOnline()),
 				String.valueOf(ping.getPlayers().getMax()),
-				String.valueOf(randomId), // Needs to be unique per server (on a LAN?)
+				randomId, // Needs to be unique per server (on a LAN?)
 				"ProtocolSupportPE",
 				"Survival"
 			);


### PR DESCRIPTION
The unknown field in getServerInfo() in PEProxyServerInfoHandler is indeed some kind of ID. It must be unique per server instance, otherwise PE client will lump all servers on the LAN with the same ID together. Without this fix, it was not possible to run two different instances of PSPE on a LAN (and see them as separate).