### PR TITLE
NullPointerException

### DIFF
--- a/src/protocolsupport/zplatform/impl/spigot/network/handler/SpigotLoginListenerPlay.java
+++ b/src/protocolsupport/zplatform/impl/spigot/network/handler/SpigotLoginListenerPlay.java
@@ -105,7 +105,7 @@ public class SpigotLoginListenerPlay extends AbstractLoginListenerPlay implement
 		InetSocketAddress socketaddress = networkManager.getAddress();
 		if (playerlist.getProfileBans().isBanned(mojangGameProfile)) {
 			GameProfileBanEntry profileban = playerlist.getProfileBans().get(mojangGameProfile);
-			if (!hasExpired(profileban)) {
+			if (profileban != null && !hasExpired(profileban)) {
 				String reason = "You are banned from this server!\nReason: " + profileban.getReason();
 				if (profileban.getExpires() != null) {
 					reason = reason + "\nYour ban will be removed on " +  new SimpleDateFormat(BAN_DATE_FORMAT_STRING).format(profileban.getExpires());
@@ -116,7 +116,7 @@ public class SpigotLoginListenerPlay extends AbstractLoginListenerPlay implement
 			event.disallow(PlayerLoginEvent.Result.KICK_WHITELIST, SpigotConfig.whitelistMessage);
 		} else if (playerlist.getIPBans().isBanned(socketaddress)) {
 			IpBanEntry ipban = playerlist.getIPBans().get(socketaddress);
-			if (!hasExpired(ipban)) {
+			if (profileban != null && !hasExpired(ipban)) {
 				String reason = "Your IP address is banned from this server!\nReason: " + ipban.getReason();
 				if (ipban.getExpires() != null) {
 					reason = reason + "\nYour ban will be removed on " + new SimpleDateFormat(BAN_DATE_FORMAT_STRING).format(ipban.getExpires());

--- a/src/protocolsupport/zplatform/impl/spigot/network/handler/SpigotLoginListenerPlay.java
+++ b/src/protocolsupport/zplatform/impl/spigot/network/handler/SpigotLoginListenerPlay.java
@@ -116,7 +116,7 @@ public class SpigotLoginListenerPlay extends AbstractLoginListenerPlay implement
 			event.disallow(PlayerLoginEvent.Result.KICK_WHITELIST, SpigotConfig.whitelistMessage);
 		} else if (playerlist.getIPBans().isBanned(socketaddress)) {
 			IpBanEntry ipban = playerlist.getIPBans().get(socketaddress);
-			if (profileban != null && !hasExpired(ipban)) {
+			if (ipban != null && !hasExpired(ipban)) {
 				String reason = "Your IP address is banned from this server!\nReason: " + ipban.getReason();
 				if (ipban.getExpires() != null) {
 					reason = reason + "\nYour ban will be removed on " + new SimpleDateFormat(BAN_DATE_FORMAT_STRING).format(ipban.getExpires());


### PR DESCRIPTION
In Minecraft 1.13.2, the method playerlist.getProfileBans().isBanned(mojangGameProfile) (Line 106) returns true if the player has been banned BUT doesn't check if it's expired.
The method playerlist.getProfileBans().get(mojangGameProfile) (Line 107) returns the ban BUT check if it's expired. If the ban is expired, it returns null.
Here, a NullPointerException is throw at line 132 ( https://prnt.sc/qin341 )
Minecraft has fixed this problem in 1.15 but that could be good to fix in ProtocolSupport 1.13.2