### PR TITLE
Some entities remapping

### DIFF
--- a/src/protocolsupport/protocol/typeremapper/entity/EntityRemappersRegistry.java
+++ b/src/protocolsupport/protocol/typeremapper/entity/EntityRemappersRegistry.java
@@ -17,25 +17,7 @@ import protocolsupport.protocol.typeremapper.entity.metadata.types.base.AgeableE
 import protocolsupport.protocol.typeremapper.entity.metadata.types.base.BaseEntityMetadataRemapper;
 import protocolsupport.protocol.typeremapper.entity.metadata.types.base.InsentientEntityMetadataRemapper;
 import protocolsupport.protocol.typeremapper.entity.metadata.types.base.LivingEntityMetadataRemapper;
-import protocolsupport.protocol.typeremapper.entity.metadata.types.living.BatEntityMetadataRemapper;
-import protocolsupport.protocol.typeremapper.entity.metadata.types.living.BlazeEntityMetadataRemapper;
-import protocolsupport.protocol.typeremapper.entity.metadata.types.living.CreeperEntityMetadataRemapper;
-import protocolsupport.protocol.typeremapper.entity.metadata.types.living.EnderDragonEntityMetadataRemapper;
-import protocolsupport.protocol.typeremapper.entity.metadata.types.living.EndermanEntityMetadataRemapper;
-import protocolsupport.protocol.typeremapper.entity.metadata.types.living.GhastEntityMetadataRemapper;
-import protocolsupport.protocol.typeremapper.entity.metadata.types.living.GuardianEntityMetadataRemapper;
-import protocolsupport.protocol.typeremapper.entity.metadata.types.living.IllagerEntityMetadataRemapper;
-import protocolsupport.protocol.typeremapper.entity.metadata.types.living.IronGolemEntityMetadataRemapper;
-import protocolsupport.protocol.typeremapper.entity.metadata.types.living.PhantomEntityMetadataRemapper;
-import protocolsupport.protocol.typeremapper.entity.metadata.types.living.PillagerEntityMetadataRemapper;
-import protocolsupport.protocol.typeremapper.entity.metadata.types.living.ShulkerEntityMetadataRemapper;
-import protocolsupport.protocol.typeremapper.entity.metadata.types.living.SlimeEntityMetadataRemapper;
-import protocolsupport.protocol.typeremapper.entity.metadata.types.living.SnowmanEntityMetadataRemapper;
-import protocolsupport.protocol.typeremapper.entity.metadata.types.living.SpellcasterIllagerEntityMetadataRemapper;
-import protocolsupport.protocol.typeremapper.entity.metadata.types.living.SpiderEntityMetadataRemapper;
-import protocolsupport.protocol.typeremapper.entity.metadata.types.living.VexEntityMetadataRemapper;
-import protocolsupport.protocol.typeremapper.entity.metadata.types.living.WitchEntityMetadataRemapper;
-import protocolsupport.protocol.typeremapper.entity.metadata.types.living.WitherEntityMetadataRemapper;
+import protocolsupport.protocol.typeremapper.entity.metadata.types.living.*;
 import protocolsupport.protocol.typeremapper.entity.metadata.types.living.ageable.BeeEntityMetadataRemapper;
 import protocolsupport.protocol.typeremapper.entity.metadata.types.living.ageable.FoxEntityMetadataRemapper;
 import protocolsupport.protocol.typeremapper.entity.metadata.types.living.ageable.PandaEntityMetadataRemapper;
@@ -299,7 +281,7 @@ public class EntityRemappersRegistry {
 			.register();
 			new Mapping(NetworkEntityType.ELDER_GUARDIAN)
 			.addMapping(NetworkEntityType.ELDER_GUARDIAN, GuardianEntityMetadataRemapper.INSTANCE, ProtocolVersionsHelper.UP_1_11)
-			.addMapping(NetworkEntityType.GUARDIAN, GuardianEntityMetadataRemapper.INSTANCE, ProtocolVersion.getAllBetween(ProtocolVersion.MINECRAFT_1_10, ProtocolVersion.MINECRAFT_1_8))
+			.addMapping(NetworkEntityType.GUARDIAN, new ElderGuardianEntityMetadataRemapper(), ProtocolVersion.getAllBetween(ProtocolVersion.MINECRAFT_1_10, ProtocolVersion.MINECRAFT_1_8))
 			.addMapping(NetworkEntityType.SQUID, InsentientEntityMetadataRemapper.INSTANCE, ProtocolVersionsHelper.BEFORE_1_8)
 			.register();
 			new Mapping(NetworkEntityType.VINDICATOR)

--- a/src/protocolsupport/protocol/typeremapper/entity/EntityRemappersRegistry.java
+++ b/src/protocolsupport/protocol/typeremapper/entity/EntityRemappersRegistry.java
@@ -12,11 +12,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import protocolsupport.api.ProtocolVersion;
 import protocolsupport.protocol.typeremapper.entity.metadata.object.NetworkEntityMetadataObjectRemapper;
 import protocolsupport.protocol.typeremapper.entity.metadata.types.EntityMetadataRemapper;
-import protocolsupport.protocol.typeremapper.entity.metadata.types.base.AbstractMerchantEntityMetadataRemapper;
-import protocolsupport.protocol.typeremapper.entity.metadata.types.base.AgeableEntityMetadataRemapper;
-import protocolsupport.protocol.typeremapper.entity.metadata.types.base.BaseEntityMetadataRemapper;
-import protocolsupport.protocol.typeremapper.entity.metadata.types.base.InsentientEntityMetadataRemapper;
-import protocolsupport.protocol.typeremapper.entity.metadata.types.base.LivingEntityMetadataRemapper;
+import protocolsupport.protocol.typeremapper.entity.metadata.types.base.*;
 import protocolsupport.protocol.typeremapper.entity.metadata.types.living.*;
 import protocolsupport.protocol.typeremapper.entity.metadata.types.living.ageable.*;
 import protocolsupport.protocol.typeremapper.entity.metadata.types.living.fish.FishEntityMetadataRemapper;
@@ -341,8 +337,8 @@ public class EntityRemappersRegistry {
 			.addMapping(NetworkEntityType.SPIDER, LivingEntityMetadataRemapper.INSTANCE, ProtocolVersionsHelper.BEFORE_1_10)
 			.register();
 			new Mapping(NetworkEntityType.CAT)
-			.addMapping(NetworkEntityType.CAT, new CatEntityMetadataRemapper(), ProtocolVersionsHelper.UP_1_14)
-			.addMapping(NetworkEntityType.OCELOT, AgeableEntityMetadataRemapper.INSTANCE, ProtocolVersionsHelper.BEFORE_1_14)
+			.addMapping(NetworkEntityType.CAT, CatEntityMetadataRemapper.INSTANCE, ProtocolVersionsHelper.UP_1_14)
+			.addMapping(NetworkEntityType.OCELOT, CatEntityMetadataRemapper.INSTANCE, ProtocolVersionsHelper.BEFORE_1_14)
 			.register();
 			new Mapping(NetworkEntityType.FOX)
 			.addMapping(NetworkEntityType.FOX, new FoxEntityMetadataRemapper(), ProtocolVersionsHelper.UP_1_14)

--- a/src/protocolsupport/protocol/typeremapper/entity/EntityRemappersRegistry.java
+++ b/src/protocolsupport/protocol/typeremapper/entity/EntityRemappersRegistry.java
@@ -163,8 +163,8 @@ public class EntityRemappersRegistry {
 			.addMapping(NetworkEntityType.PIG, new PigEntityMetadataRemapper(), ProtocolVersionsHelper.ALL_PC)
 			.register();
 			new Mapping(NetworkEntityType.RABBIT)
-			.addMapping(NetworkEntityType.RABBIT, new RabbitEntityMetadataRemapper(), ProtocolVersionsHelper.UP_1_9)
-			.addMapping(NetworkEntityType.CHICKEN, AgeableEntityMetadataRemapper.INSTANCE, ProtocolVersionsHelper.BEFORE_1_9)
+			.addMapping(NetworkEntityType.RABBIT, new RabbitEntityMetadataRemapper(), ProtocolVersionsHelper.UP_1_8)
+			.addMapping(NetworkEntityType.CHICKEN, AgeableEntityMetadataRemapper.INSTANCE, ProtocolVersionsHelper.BEFORE_1_8)
 			.register();
 			new Mapping(NetworkEntityType.SHEEP)
 			.addMapping(NetworkEntityType.SHEEP, new SheepEntityMetadataRemapper(), ProtocolVersionsHelper.ALL_PC)

--- a/src/protocolsupport/protocol/typeremapper/entity/EntityRemappersRegistry.java
+++ b/src/protocolsupport/protocol/typeremapper/entity/EntityRemappersRegistry.java
@@ -18,15 +18,7 @@ import protocolsupport.protocol.typeremapper.entity.metadata.types.base.BaseEnti
 import protocolsupport.protocol.typeremapper.entity.metadata.types.base.InsentientEntityMetadataRemapper;
 import protocolsupport.protocol.typeremapper.entity.metadata.types.base.LivingEntityMetadataRemapper;
 import protocolsupport.protocol.typeremapper.entity.metadata.types.living.*;
-import protocolsupport.protocol.typeremapper.entity.metadata.types.living.ageable.BeeEntityMetadataRemapper;
-import protocolsupport.protocol.typeremapper.entity.metadata.types.living.ageable.FoxEntityMetadataRemapper;
-import protocolsupport.protocol.typeremapper.entity.metadata.types.living.ageable.PandaEntityMetadataRemapper;
-import protocolsupport.protocol.typeremapper.entity.metadata.types.living.ageable.PigEntityMetadataRemapper;
-import protocolsupport.protocol.typeremapper.entity.metadata.types.living.ageable.PolarBearEntityMetadataRemapper;
-import protocolsupport.protocol.typeremapper.entity.metadata.types.living.ageable.RabbitEntityMetadataRemapper;
-import protocolsupport.protocol.typeremapper.entity.metadata.types.living.ageable.SheepEntityMetadataRemapper;
-import protocolsupport.protocol.typeremapper.entity.metadata.types.living.ageable.TurtleEntityMetadataRemapper;
-import protocolsupport.protocol.typeremapper.entity.metadata.types.living.ageable.VillagerEntityMetadataRemapper;
+import protocolsupport.protocol.typeremapper.entity.metadata.types.living.ageable.*;
 import protocolsupport.protocol.typeremapper.entity.metadata.types.living.fish.FishEntityMetadataRemapper;
 import protocolsupport.protocol.typeremapper.entity.metadata.types.living.fish.PufferFishEntityMetadataRemapper;
 import protocolsupport.protocol.typeremapper.entity.metadata.types.living.fish.TropicalFishEntityMetadataRemapper;
@@ -124,7 +116,8 @@ public class EntityRemappersRegistry {
 			.addMapping(NetworkEntityType.COW, AgeableEntityMetadataRemapper.INSTANCE, ProtocolVersionsHelper.ALL_PC)
 			.register();
 			new Mapping(NetworkEntityType.MUSHROOM_COW)
-			.addMapping(NetworkEntityType.MUSHROOM_COW, AgeableEntityMetadataRemapper.INSTANCE, ProtocolVersionsHelper.ALL_PC)
+			.addMapping(NetworkEntityType.MUSHROOM_COW, new MushroomCowEntityMetadataRemapper(), ProtocolVersionsHelper.UP_1_14)
+			.addMapping(NetworkEntityType.MUSHROOM_COW, AgeableEntityMetadataRemapper.INSTANCE, ProtocolVersionsHelper.BEFORE_1_14)
 			.register();
 			new Mapping(NetworkEntityType.CHICKEN)
 			.addMapping(NetworkEntityType.CHICKEN, AgeableEntityMetadataRemapper.INSTANCE, ProtocolVersionsHelper.ALL_PC)

--- a/src/protocolsupport/protocol/typeremapper/entity/metadata/types/living/ElderGuardianEntityMetadataRemapper.java
+++ b/src/protocolsupport/protocol/typeremapper/entity/metadata/types/living/ElderGuardianEntityMetadataRemapper.java
@@ -1,0 +1,20 @@
+package protocolsupport.protocol.typeremapper.entity.metadata.types.living;
+
+import protocolsupport.api.ProtocolVersion;
+import protocolsupport.protocol.typeremapper.entity.metadata.object.value.IndexValueRemapper;
+import protocolsupport.protocol.typeremapper.entity.metadata.object.value.IndexValueRemapperNoOp;
+import protocolsupport.protocol.typeremapper.entity.metadata.object.value.IndexValueRemapperNumberToInt;
+import protocolsupport.protocol.typeremapper.entity.metadata.types.base.InsentientEntityMetadataRemapper;
+import protocolsupport.protocol.types.networkentity.metadata.NetworkEntityMetadataObject;
+import protocolsupport.protocol.types.networkentity.metadata.NetworkEntityMetadataObjectIndex;
+import protocolsupport.protocol.types.networkentity.metadata.objects.NetworkEntityMetadataObjectBoolean;
+import protocolsupport.protocol.types.networkentity.metadata.objects.NetworkEntityMetadataObjectByte;
+import protocolsupport.protocol.types.networkentity.metadata.objects.NetworkEntityMetadataObjectInt;
+import protocolsupport.protocol.utils.ProtocolVersionsHelper;
+
+public class ElderGuardianEntityMetadataRemapper extends GuardianEntityMetadataRemapper {
+
+	public ElderGuardianEntityMetadataRemapper() {
+		super(true);
+	}
+}

--- a/src/protocolsupport/protocol/typeremapper/entity/metadata/types/living/GuardianEntityMetadataRemapper.java
+++ b/src/protocolsupport/protocol/typeremapper/entity/metadata/types/living/GuardianEntityMetadataRemapper.java
@@ -2,6 +2,7 @@ package protocolsupport.protocol.typeremapper.entity.metadata.types.living;
 
 import protocolsupport.api.ProtocolVersion;
 import protocolsupport.protocol.typeremapper.entity.metadata.object.value.IndexValueRemapper;
+import protocolsupport.protocol.typeremapper.entity.metadata.object.value.IndexValueRemapperBooleanToByte;
 import protocolsupport.protocol.typeremapper.entity.metadata.object.value.IndexValueRemapperNoOp;
 import protocolsupport.protocol.typeremapper.entity.metadata.object.value.IndexValueRemapperNumberToInt;
 import protocolsupport.protocol.typeremapper.entity.metadata.types.base.InsentientEntityMetadataRemapper;
@@ -14,28 +15,28 @@ import protocolsupport.protocol.utils.ProtocolVersionsHelper;
 
 public class GuardianEntityMetadataRemapper extends InsentientEntityMetadataRemapper {
 
-	public static final GuardianEntityMetadataRemapper INSTANCE = new GuardianEntityMetadataRemapper();
+	public static final GuardianEntityMetadataRemapper INSTANCE = new GuardianEntityMetadataRemapper(false);
 
-	public GuardianEntityMetadataRemapper() {
+	public GuardianEntityMetadataRemapper(boolean isElder) {
 		addRemap(new IndexValueRemapperNoOp(NetworkEntityMetadataObjectIndex.Guardian.SPIKES, 15), ProtocolVersionsHelper.UP_1_15);
 		addRemap(new IndexValueRemapperNoOp(NetworkEntityMetadataObjectIndex.Guardian.SPIKES, 14), ProtocolVersionsHelper.ALL_1_14);
 		addRemap(new IndexValueRemapperNoOp(NetworkEntityMetadataObjectIndex.Guardian.SPIKES, 12), ProtocolVersionsHelper.RANGE__1_11__1_13_2);
 		addRemap(new IndexValueRemapper<NetworkEntityMetadataObjectBoolean>(NetworkEntityMetadataObjectIndex.Guardian.SPIKES, 12) {
 			@Override
 			public NetworkEntityMetadataObject<?> remapValue(NetworkEntityMetadataObjectBoolean object) {
-				return new NetworkEntityMetadataObjectByte(object.getValue() ? (byte) 2 : (byte) 0);
+				return new NetworkEntityMetadataObjectByte(isElder ? (byte) 4 :(byte) 2);
 			}
 		}, ProtocolVersion.MINECRAFT_1_10);
 		addRemap(new IndexValueRemapper<NetworkEntityMetadataObjectBoolean>(NetworkEntityMetadataObjectIndex.Guardian.SPIKES, 11) {
 			@Override
 			public NetworkEntityMetadataObject<?> remapValue(NetworkEntityMetadataObjectBoolean object) {
-				return new NetworkEntityMetadataObjectByte(object.getValue() ? (byte) 2 : (byte) 0);
+				return new NetworkEntityMetadataObjectByte(isElder ? (byte) 4 :(byte) 2);
 			}
 		}, ProtocolVersionsHelper.ALL_1_9);
 		addRemap(new IndexValueRemapper<NetworkEntityMetadataObjectBoolean>(NetworkEntityMetadataObjectIndex.Guardian.SPIKES, 16) {
 			@Override
 			public NetworkEntityMetadataObject<?> remapValue(NetworkEntityMetadataObjectBoolean object) {
-				return new NetworkEntityMetadataObjectInt(object.getValue() ? (byte) 2 : (byte) 0);
+				return new NetworkEntityMetadataObjectInt(isElder ? 4 : 2);
 			}
 		}, ProtocolVersion.MINECRAFT_1_8);
 
@@ -45,5 +46,4 @@ public class GuardianEntityMetadataRemapper extends InsentientEntityMetadataRema
 		addRemap(new IndexValueRemapperNoOp(NetworkEntityMetadataObjectIndex.Guardian.TARGET_ID, 12), ProtocolVersionsHelper.ALL_1_9);
 		addRemap(new IndexValueRemapperNumberToInt(NetworkEntityMetadataObjectIndex.Guardian.TARGET_ID, 17), ProtocolVersion.MINECRAFT_1_8);
 	}
-
 }

--- a/src/protocolsupport/protocol/typeremapper/entity/metadata/types/living/ageable/MushroomCowEntityMetadataRemapper.java
+++ b/src/protocolsupport/protocol/typeremapper/entity/metadata/types/living/ageable/MushroomCowEntityMetadataRemapper.java
@@ -1,0 +1,15 @@
+package protocolsupport.protocol.typeremapper.entity.metadata.types.living.ageable;
+
+import protocolsupport.protocol.typeremapper.entity.metadata.object.value.IndexValueRemapperNoOp;
+import protocolsupport.protocol.typeremapper.entity.metadata.types.base.AgeableEntityMetadataRemapper;
+import protocolsupport.protocol.types.networkentity.metadata.NetworkEntityMetadataObjectIndex;
+import protocolsupport.protocol.utils.ProtocolVersionsHelper;
+
+public class MushroomCowEntityMetadataRemapper extends AgeableEntityMetadataRemapper {
+
+	public MushroomCowEntityMetadataRemapper() {
+		addRemap(new IndexValueRemapperNoOp(NetworkEntityMetadataObjectIndex.Mushroom.VARIANT, 16), ProtocolVersionsHelper.UP_1_15);
+		addRemap(new IndexValueRemapperNoOp(NetworkEntityMetadataObjectIndex.Mushroom.VARIANT, 15), ProtocolVersionsHelper.ALL_1_14);
+	}
+
+}

--- a/src/protocolsupport/protocol/typeremapper/entity/metadata/types/living/tameable/CatEntityMetadataRemapper.java
+++ b/src/protocolsupport/protocol/typeremapper/entity/metadata/types/living/tameable/CatEntityMetadataRemapper.java
@@ -1,11 +1,18 @@
 package protocolsupport.protocol.typeremapper.entity.metadata.types.living.tameable;
 
+import protocolsupport.api.ProtocolVersion;
+import protocolsupport.protocol.typeremapper.entity.metadata.object.value.IndexValueRemapper;
 import protocolsupport.protocol.typeremapper.entity.metadata.object.value.IndexValueRemapperNoOp;
 import protocolsupport.protocol.typeremapper.entity.metadata.types.base.TameableEntityMetadataRemapper;
+import protocolsupport.protocol.types.networkentity.metadata.NetworkEntityMetadataObject;
 import protocolsupport.protocol.types.networkentity.metadata.NetworkEntityMetadataObjectIndex;
+import protocolsupport.protocol.types.networkentity.metadata.objects.NetworkEntityMetadataObjectByte;
+import protocolsupport.protocol.types.networkentity.metadata.objects.NetworkEntityMetadataObjectVarInt;
 import protocolsupport.protocol.utils.ProtocolVersionsHelper;
 
 public class CatEntityMetadataRemapper extends TameableEntityMetadataRemapper {
+
+	public static final CatEntityMetadataRemapper INSTANCE = new CatEntityMetadataRemapper();
 
 	public CatEntityMetadataRemapper() {
 		addRemap(new IndexValueRemapperNoOp(NetworkEntityMetadataObjectIndex.Cat.VARIANT, 18), ProtocolVersionsHelper.UP_1_15);
@@ -19,6 +26,37 @@ public class CatEntityMetadataRemapper extends TameableEntityMetadataRemapper {
 
 		addRemap(new IndexValueRemapperNoOp(NetworkEntityMetadataObjectIndex.Cat.COLLAR_COLOR, 21), ProtocolVersionsHelper.UP_1_15);
 		addRemap(new IndexValueRemapperNoOp(NetworkEntityMetadataObjectIndex.Cat.COLLAR_COLOR, 20), ProtocolVersionsHelper.ALL_1_14);
+
+		addRemap(new IndexValueRemapper<NetworkEntityMetadataObjectVarInt>(NetworkEntityMetadataObjectIndex.Cat.VARIANT, 15) {
+			@Override
+			public NetworkEntityMetadataObject<?> remapValue(NetworkEntityMetadataObjectVarInt object) {
+				return new NetworkEntityMetadataObjectVarInt(getLegacyCatVariant(object.getValue()));
+			}
+		}, ProtocolVersionsHelper.RANGE__1_10__1_13_2);
+
+		addRemap(new IndexValueRemapper<NetworkEntityMetadataObjectVarInt>(NetworkEntityMetadataObjectIndex.Cat.VARIANT, 14) {
+			@Override
+			public NetworkEntityMetadataObject<?> remapValue(NetworkEntityMetadataObjectVarInt object) {
+				return new NetworkEntityMetadataObjectVarInt(getLegacyCatVariant(object.getValue()));
+			}
+		}, ProtocolVersionsHelper.ALL_1_9);
+
+		addRemap(new IndexValueRemapper<NetworkEntityMetadataObjectVarInt>(NetworkEntityMetadataObjectIndex.Cat.VARIANT, 18) {
+			@Override
+			public NetworkEntityMetadataObject<?> remapValue(NetworkEntityMetadataObjectVarInt object) {
+				return new NetworkEntityMetadataObjectByte((byte) getLegacyCatVariant(object.getValue()));
+			}
+		}, ProtocolVersionsHelper.BEFORE_1_9);
+
+	}
+
+	private int getLegacyCatVariant(int currentType){
+		switch (currentType){
+			case 10: return 1;
+			case 0: case 5: case 6: return 2;
+			case 4: case 7: case 8: case 9: return 3;
+			default: return currentType;
+		}
 	}
 
 }

--- a/src/protocolsupport/protocol/typeremapper/entity/metadata/types/object/arrow/ArrowEntityMetadataRemapper.java
+++ b/src/protocolsupport/protocol/typeremapper/entity/metadata/types/object/arrow/ArrowEntityMetadataRemapper.java
@@ -1,6 +1,9 @@
 package protocolsupport.protocol.typeremapper.entity.metadata.types.object.arrow;
 
+import protocolsupport.api.ProtocolVersion;
 import protocolsupport.protocol.typeremapper.entity.metadata.object.value.IndexValueRemapperNoOp;
+import protocolsupport.protocol.typeremapper.entity.metadata.object.value.IndexValueRemapperNumberToByte;
+import protocolsupport.protocol.typeremapper.entity.metadata.object.value.IndexValueRemapperNumberToInt;
 import protocolsupport.protocol.typeremapper.entity.metadata.types.base.BaseEntityMetadataRemapper;
 import protocolsupport.protocol.types.networkentity.metadata.NetworkEntityMetadataObjectIndex;
 import protocolsupport.protocol.utils.ProtocolVersionsHelper;
@@ -11,12 +14,12 @@ public class ArrowEntityMetadataRemapper extends BaseEntityMetadataRemapper {
 
 	public ArrowEntityMetadataRemapper() {
 		addRemap(new IndexValueRemapperNoOp(NetworkEntityMetadataObjectIndex.Arrow.CIRTICAL, 7), ProtocolVersionsHelper.UP_1_14);
-		addRemap(new IndexValueRemapperNoOp(NetworkEntityMetadataObjectIndex.Arrow.CIRTICAL, 6), ProtocolVersionsHelper.RANGE__1_10__1_13_2);
+		addRemap(new IndexValueRemapperNoOp(NetworkEntityMetadataObjectIndex.Arrow.CIRTICAL, 6), ProtocolVersion.getAllBetween(ProtocolVersion.MINECRAFT_1_10, ProtocolVersion.MINECRAFT_1_13_2));
 		addRemap(new IndexValueRemapperNoOp(NetworkEntityMetadataObjectIndex.Arrow.CIRTICAL, 5), ProtocolVersionsHelper.ALL_1_9);
 		addRemap(new IndexValueRemapperNoOp(NetworkEntityMetadataObjectIndex.Arrow.CIRTICAL, 15), ProtocolVersionsHelper.BEFORE_1_9);
 
 		addRemap(new IndexValueRemapperNoOp(NetworkEntityMetadataObjectIndex.Arrow.SHOOTER, 8), ProtocolVersionsHelper.UP_1_14);
-		addRemap(new IndexValueRemapperNoOp(NetworkEntityMetadataObjectIndex.Arrow.SHOOTER, 7), ProtocolVersionsHelper.ALL_1_13);
+		addRemap(new IndexValueRemapperNoOp(NetworkEntityMetadataObjectIndex.Arrow.SHOOTER, 7), ProtocolVersion.getAllBetween(ProtocolVersion.MINECRAFT_1_13_1, ProtocolVersion.MINECRAFT_1_13_2));
 
 		addRemap(new IndexValueRemapperNoOp(NetworkEntityMetadataObjectIndex.Arrow.PIERCING_LEVEL, 9), ProtocolVersionsHelper.UP_1_14);
 	}

--- a/src/protocolsupport/protocol/typeremapper/entity/metadata/types/object/arrow/TippedArrowEntityMetadataRemapper.java
+++ b/src/protocolsupport/protocol/typeremapper/entity/metadata/types/object/arrow/TippedArrowEntityMetadataRemapper.java
@@ -1,15 +1,36 @@
 package protocolsupport.protocol.typeremapper.entity.metadata.types.object.arrow;
 
+import protocolsupport.api.ProtocolVersion;
+import protocolsupport.protocol.typeremapper.entity.metadata.object.value.IndexValueRemapper;
 import protocolsupport.protocol.typeremapper.entity.metadata.object.value.IndexValueRemapperNoOp;
+import protocolsupport.protocol.types.networkentity.metadata.NetworkEntityMetadataObject;
 import protocolsupport.protocol.types.networkentity.metadata.NetworkEntityMetadataObjectIndex;
+import protocolsupport.protocol.types.networkentity.metadata.objects.NetworkEntityMetadataObjectByte;
+import protocolsupport.protocol.types.networkentity.metadata.objects.NetworkEntityMetadataObjectInt;
+import protocolsupport.protocol.types.networkentity.metadata.objects.NetworkEntityMetadataObjectVarInt;
 import protocolsupport.protocol.utils.ProtocolVersionsHelper;
 
 public class TippedArrowEntityMetadataRemapper extends ArrowEntityMetadataRemapper {
 
 	public TippedArrowEntityMetadataRemapper() {
 		addRemap(new IndexValueRemapperNoOp(NetworkEntityMetadataObjectIndex.TippedArrow.COLOR, 10), ProtocolVersionsHelper.UP_1_14);
-		addRemap(new IndexValueRemapperNoOp(NetworkEntityMetadataObjectIndex.TippedArrow.COLOR, 8), ProtocolVersionsHelper.RANGE__1_10__1_13_2);
-		addRemap(new IndexValueRemapperNoOp(NetworkEntityMetadataObjectIndex.TippedArrow.COLOR, 6), ProtocolVersionsHelper.ALL_1_9);
+		addRemap(new IndexValueRemapperNoOp(NetworkEntityMetadataObjectIndex.TippedArrow.COLOR, 8), ProtocolVersion.getAllBetween(ProtocolVersion.MINECRAFT_1_13_1, ProtocolVersion.MINECRAFT_1_13_2));
+		addRemap(new IndexValueRemapperNoOp(NetworkEntityMetadataObjectIndex.TippedArrow.COLOR, 7), ProtocolVersion.getAllBetween(ProtocolVersion.MINECRAFT_1_11_1, ProtocolVersion.MINECRAFT_1_13));
+
+		addRemap(new IndexValueRemapper<NetworkEntityMetadataObjectVarInt>(NetworkEntityMetadataObjectIndex.TippedArrow.COLOR, 7) {
+			@Override
+			public NetworkEntityMetadataObject<?> remapValue(NetworkEntityMetadataObjectVarInt object) {
+				return new NetworkEntityMetadataObjectVarInt(object.getValue() == -1 ? 0 : object.getValue());
+			}
+		}, ProtocolVersion.getAllBetween(ProtocolVersion.MINECRAFT_1_10, ProtocolVersion.MINECRAFT_1_11));
+
+		addRemap(new IndexValueRemapper<NetworkEntityMetadataObjectVarInt>(NetworkEntityMetadataObjectIndex.TippedArrow.COLOR, 6) {
+			@Override
+			public NetworkEntityMetadataObject<?> remapValue(NetworkEntityMetadataObjectVarInt object) {
+				return new NetworkEntityMetadataObjectVarInt(object.getValue() == -1 ? 0 : object.getValue());
+			}
+		}, ProtocolVersionsHelper.ALL_1_9);
+
 	}
 
 }

--- a/src/protocolsupport/protocol/types/networkentity/metadata/NetworkEntityMetadataObjectIndex.java
+++ b/src/protocolsupport/protocol/types/networkentity/metadata/NetworkEntityMetadataObjectIndex.java
@@ -161,6 +161,10 @@ public class NetworkEntityMetadataObjectIndex<T extends NetworkEntityMetadataObj
 		public static final NetworkEntityMetadataObjectIndex<NetworkEntityMetadataObjectVarInt> BOOST_TIME = takeNextIndex(NetworkEntityMetadataObjectVarInt.class);
 	}
 
+	public static class Mushroom extends Ageable {
+		public static final NetworkEntityMetadataObjectIndex<NetworkEntityMetadataObjectString> VARIANT = takeNextIndex(NetworkEntityMetadataObjectString.class);
+	}
+
 	public static class Rabbit extends Ageable {
 		public static final NetworkEntityMetadataObjectIndex<NetworkEntityMetadataObjectVarInt> VARIANT = takeNextIndex(NetworkEntityMetadataObjectVarInt.class);
 	}


### PR DESCRIPTION
First of all, the majority of this remapping is due to things that I've seen by testing different clients (from 1.8.9) in a 1.15.2 paper server, using the latest development version which could be found at that moment (just some days ago). I've searched for that entities in the list of issues but not all of them were there, and I'm not sure if it'd have been better to create the issue and after that create the PR, anyway, I'm going to explain the things I've changed and why if needed.

- Rabbits were introduced in 1.8, but they were being remapped as chickens in that version.
- Added the brown mushroom remap ( from #1174 )
- Fixed the elder guardian remap (clients from 1.8 to 1.10 were seeing them like normal guardians, his metadata value used in previous versions to check if it was elder or not was functional just in older versions, before the entity was separated into a new kind of entity in 1.11, but using the same metadata field to check values about his spinnes, which previously also contained the elder guardian status, as I told earlier, but not since 1.11).
- Added legacy cat remap, I didn't write in the commit but it's from #1137, I've just assign them by the closest legacy color, although I've got some doubts about specific variants. It also shows the cats sit properly.
- Fixed a crash with arrows and tipped arrows for 1.13 clients (the shooter metadata value didn't exist until 1.13.1, so when a 1.13 client shoot an arrow or tipped arrow, it'd crash), as well as some tipped arrow colors fix (0 indicates no color in some versions, and it was changed to -1).

I guess that in some moment the default values used in some of the fixes could change as long as the minecraft protocol changes that values, making it non-functional in a future, but in 1.15.2, this seems to fix that problems. I've just tested all this changes from versions 1.8.9 to 1.15.2, including all his intermediate released versions.