### PR TITLE
Cancel special-case block place packets from 1.8->1.9

### DIFF
--- a/src/protocolsupport/protocol/packet/middleimpl/serverbound/play/v_4_5_6_7/BlockPlace.java
+++ b/src/protocolsupport/protocol/packet/middleimpl/serverbound/play/v_4_5_6_7/BlockPlace.java
@@ -2,6 +2,7 @@ package protocolsupport.protocol.packet.middleimpl.serverbound.play.v_4_5_6_7;
 
 import io.netty.buffer.ByteBuf;
 import protocolsupport.protocol.ConnectionImpl;
+import protocolsupport.protocol.packet.middle.CancelMiddlePacketException;
 import protocolsupport.protocol.packet.middle.serverbound.play.MiddleBlockPlace;
 import protocolsupport.protocol.serializer.ItemStackSerializer;
 import protocolsupport.protocol.serializer.PositionSerializer;
@@ -20,9 +21,19 @@ public class BlockPlace extends MiddleBlockPlace {
 		PositionSerializer.readLegacyPositionBTo(clientdata, position);
 		face = clientdata.readByte();
 		ItemStackSerializer.readItemStack(clientdata, version);
-		cX = clientdata.readUnsignedByte() / 16.0F;
-		cY = clientdata.readUnsignedByte() / 16.0F;
-		cZ = clientdata.readUnsignedByte() / 16.0F;
+
+		byte cursorX = clientdata.readByte();
+		byte cursorY = clientdata.readByte();
+		byte cursorZ = clientdata.readByte();
+
+		// Cancel "special case" packets because they are not sent on 1.9
+		if(cursorX == -1 && cursorY == -1 && cursorZ == -1 && face == -1) {
+			throw CancelMiddlePacketException.INSTANCE;
+		}
+
+		cX = Byte.toUnsignedInt(cursorX) / 16.0F;
+		cY = Byte.toUnsignedInt(cursorY) / 16.0F;
+		cZ = Byte.toUnsignedInt(cursorZ) / 16.0F;
 	}
 
 }

--- a/src/protocolsupport/protocol/packet/middleimpl/serverbound/play/v_8/BlockPlace.java
+++ b/src/protocolsupport/protocol/packet/middleimpl/serverbound/play/v_8/BlockPlace.java
@@ -2,6 +2,7 @@ package protocolsupport.protocol.packet.middleimpl.serverbound.play.v_8;
 
 import io.netty.buffer.ByteBuf;
 import protocolsupport.protocol.ConnectionImpl;
+import protocolsupport.protocol.packet.middle.CancelMiddlePacketException;
 import protocolsupport.protocol.packet.middle.serverbound.play.MiddleBlockPlace;
 import protocolsupport.protocol.serializer.ItemStackSerializer;
 import protocolsupport.protocol.serializer.PositionSerializer;
@@ -20,9 +21,19 @@ public class BlockPlace extends MiddleBlockPlace {
 		PositionSerializer.readLegacyPositionLTo(clientdata, position);
 		face = clientdata.readByte();
 		ItemStackSerializer.readItemStack(clientdata, version);
-		cX = clientdata.readUnsignedByte() / 16.0F;
-		cY = clientdata.readUnsignedByte() / 16.0F;
-		cZ = clientdata.readUnsignedByte() / 16.0F;
+
+		byte cursorX = clientdata.readByte();
+		byte cursorY = clientdata.readByte();
+		byte cursorZ = clientdata.readByte();
+
+		// Cancel "special case" packets because they are not sent on 1.9
+		if(cursorX == -1 && cursorY == -1 && cursorZ == -1 && face == -1) {
+			throw CancelMiddlePacketException.INSTANCE;
+		}
+
+		cX = Byte.toUnsignedInt(cursorX) / 16.0F;
+		cY = Byte.toUnsignedInt(cursorY) / 16.0F;
+		cZ = Byte.toUnsignedInt(cursorZ) / 16.0F;
 	}
 
 }


### PR DESCRIPTION
Basically, 1.9+ servers dont actually decode the cursor positions.
See: https://github.com/dmulloy2/PacketWrapper/blob/master/PacketWrapper/src/main/java/com/comphenix/packetwrapper/WrapperPlayClientBlockPlace.java

so, they cannot determine that a packet with -1 cursor values is a "special case" packet.
See: https://wiki.vg/index.php?title=Protocol&oldid=7368#Player_Block_Placement

This makes it to where 1.8 "special case" packets are processed as regular right clicks, which they are not.
This means that false fake player interact events get called, when the player is not actually right clicking.
For instance, when you finish eating, it sends 2 right clicks when you are holding food, where the first one is not a real interact packet.