### PR TITLE
Fix legacy scoreboard prefix having a reset appended twice

### DIFF
--- a/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_4_5_6_7_8_9r1_9r2_10_11_12r1_12r2/AbstractScoreboardTeam.java
+++ b/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_4_5_6_7_8_9r1_9r2_10_11_12r1_12r2/AbstractScoreboardTeam.java
@@ -55,10 +55,10 @@ public abstract class AbstractScoreboardTeam extends MiddleScoreboardTeam {
 		String prefixLastFormatString = ChatColor.getLastColors(prefix);
 		String formatString = format.toString();
 		if (
-			(format != ChatColor.RESET) && (prefixLastFormatString.isEmpty() ||
-			!formatString.equals(prefixLastFormatString))
+			(prefixLastFormatString.isEmpty() && (format != ChatColor.RESET)) ||
+			!formatString.equals(prefixLastFormatString)
 		) {
-			if (format.isColor()) {
+			if (format.isColor() || format == ChatColor.RESET) {
 				return LegacyChat.clampLegacyText(prefix, NFIX_LIMIT_1F) + formatString;
 			} else {
 				return LegacyChat.clampLegacyText(prefix, NFIX_LIMIT_2F) + ChatColor.RESET + formatString;

--- a/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_4_5_6_7_8_9r1_9r2_10_11_12r1_12r2/AbstractScoreboardTeam.java
+++ b/src/protocolsupport/protocol/packet/middleimpl/clientbound/play/v_4_5_6_7_8_9r1_9r2_10_11_12r1_12r2/AbstractScoreboardTeam.java
@@ -55,8 +55,8 @@ public abstract class AbstractScoreboardTeam extends MiddleScoreboardTeam {
 		String prefixLastFormatString = ChatColor.getLastColors(prefix);
 		String formatString = format.toString();
 		if (
-			(prefixLastFormatString.isEmpty() && (format != ChatColor.RESET)) ||
-			!formatString.equals(prefixLastFormatString)
+			(format != ChatColor.RESET) && (prefixLastFormatString.isEmpty() ||
+			!formatString.equals(prefixLastFormatString))
 		) {
 			if (format.isColor()) {
 				return LegacyChat.clampLegacyText(prefix, NFIX_LIMIT_1F) + formatString;


### PR DESCRIPTION
This fixes an issue affecting users joining with 1.12.2 or earlier, to a server running the latest version with ProtocolSupport, where the last four characters of the scoreboard prefix were replaced with `§r§r`.

Before:
![2021-02-20_01 42 52](https://user-images.githubusercontent.com/60436249/108587524-10086500-7322-11eb-827c-f2100a406675.png)

After:
![2021-02-20_01 43 16](https://user-images.githubusercontent.com/60436249/108587535-1bf42700-7322-11eb-8cad-1dfd3695d00e.png)